### PR TITLE
AutoDipose DataAccess.cs

### DIFF
--- a/doc/JJMasterData.Documentation/articles/usages/dataaccess.md
+++ b/doc/JJMasterData.Documentation/articles/usages/dataaccess.md
@@ -12,31 +12,24 @@ cmd.Paramneters.Add(new DataAccessCommand("@group", "G1"));
 DataTable dt = dataAccess.GetDataTable(cmd);
 ```
 
-## How maintain opened connection? 
-Keeps the database connection open,
-Allowing to execute a sequence of commands;
-
-This example shows how the KeepConnAlive method should be used:<br>
+## How to execute a sequence of commands?
+This example shows how to execute a sequence of commands:<br>
 ```csharp
    class TestClass  
    { 
-       private void Test()
-       {
-           var dao = new DataAccess())
-           try
-           {
-               dao.KeepConnAlive = true;
-               dao.SetCommand("update table1 set ...");
-               dao.SetCommand("update table2 set ...");
-           }
-           catch (Exception ex)
-           {
-               //Do Log
-           }
-           finally
-           {
-              dao.KeepConnAlive = false;
-           }
-       }
+       var dataAccess = new DataAccess())
+        try
+        {
+            var commands = new List<DataAccessCommand>
+            {
+                new("update table1 set ..."),
+                new("update table2 set ..."),
+            };
+            dataAccess.SetCommand(commands);
+        }
+        catch (Exception ex)
+        {
+            //Handle your exception
+        }
    }
 ```

--- a/src/JJMasterData.Commons/Dao/DataAccess.cs
+++ b/src/JJMasterData.Commons/Dao/DataAccess.cs
@@ -405,8 +405,7 @@ public class DataAccess
 
                 foreach (var parameter in cmd.Parameters)
                 {
-                    if (parameter.Direction == ParameterDirection.Output ||
-                        parameter.Direction == ParameterDirection.InputOutput)
+                    if (parameter.Direction is ParameterDirection.Output or ParameterDirection.InputOutput)
                         parameter.Value = dbCommand.Parameters[parameter.Name].Value;
                 }
             }
@@ -538,18 +537,18 @@ public class DataAccess
     /// <remarks>Author: Lucio Pelinson 14-04-2012</remarks>
     public int SetCommand(IEnumerable<string> sqlList)
     {
-        var cmdList = (from string sql in sqlList select new DataAccessCommand(sql)).ToList();
+        var commandList = from string sql in sqlList select new DataAccessCommand(sql);
 
-        int numberOfRowsAffected = SetCommand(cmdList);
+        int numberOfRowsAffected = SetCommand(commandList);
         return numberOfRowsAffected;
     }
 
     /// <inheritdoc cref="SetCommand(IEnumerable&lt;string&gt;)"/>
     public async Task<int> SetCommandAsync(IEnumerable<string> sqlList)
     {
-        var cmdList = sqlList.Select(sql => new DataAccessCommand(sql));
+        var commandList = sqlList.Select(sql => new DataAccessCommand(sql));
 
-        int numberOfRowsAffected = await SetCommandAsync(cmdList);
+        int numberOfRowsAffected = await SetCommandAsync(commandList);
         return numberOfRowsAffected;
     }
 

--- a/src/JJMasterData.Commons/Dao/DataAccess.cs
+++ b/src/JJMasterData.Commons/Dao/DataAccess.cs
@@ -636,9 +636,6 @@ public class DataAccess
                     }
                 }
 
-                if (!dr.IsClosed)
-                    dr.Close();
-
                 foreach (var parameter in cmd.Parameters)
                 {
                     if (parameter.Direction is ParameterDirection.Output or ParameterDirection.InputOutput)
@@ -664,7 +661,7 @@ public class DataAccess
             dbCommand.Connection = await GetConnectionAsync();
             using (dbCommand.Connection)
             {
-                var dataReader = await dbCommand.ExecuteReaderAsync(CommandBehavior.SingleRow);
+                using var dataReader = await dbCommand.ExecuteReaderAsync(CommandBehavior.SingleRow);
                 while (await dataReader.ReadAsync())
                 {
                     result = new Hashtable();
@@ -680,9 +677,6 @@ public class DataAccess
                         count += 1;
                     }
                 }
-
-                if (!dataReader.IsClosed)
-                    dataReader.Close();
 
                 foreach (var parameter in command.Parameters)
                 {

--- a/src/JJMasterData.Commons/Dao/DataAccess.cs
+++ b/src/JJMasterData.Commons/Dao/DataAccess.cs
@@ -81,47 +81,51 @@ public class DataAccess
         ConnectionProvider = connectionProviderName;
     }
 
-    public DbProviderFactory GetFactory()
+    public DbProviderFactory DbProviderFactory
     {
-        if (_factory != null) return _factory;
+        get
+        {
+            if (_factory != null)
+                return _factory;
 
-        if (ConnectionString == null)
-        {
-            var error = new StringBuilder();
-            error.AppendLine("Connection string not found in configuration file.");
-            error.AppendLine("Default connection name is [ConnectionString].");
-            error.AppendLine("Please check JJ001 for more information.");
-            error.Append("https://portal.jjconsulting.com.br/jjdoc/articles/errors/jj001.html");
-            throw new DataAccessException(error.ToString());
-        }
+            if (ConnectionString == null)
+            {
+                var error = new StringBuilder();
+                error.AppendLine("Connection string not found in configuration file.");
+                error.AppendLine("Default connection name is [ConnectionString].");
+                error.AppendLine("Please check JJ001 for more information.");
+                error.Append("https://portal.jjconsulting.com.br/jjdoc/articles/errors/jj001.html");
+                throw new DataAccessException(error.ToString());
+            }
 
-        if (ConnectionProvider == null)
-        {
-            var error = new StringBuilder();
-            error.AppendLine("Connection provider not found in configuration file.");
-            error.Append("Default connection name is [ConnectionString]");
-            throw new DataAccessException(error.ToString());
-        }
+            if (ConnectionProvider == null)
+            {
+                var error = new StringBuilder();
+                error.AppendLine("Connection provider not found in configuration file.");
+                error.Append("Default connection name is [ConnectionString]");
+                throw new DataAccessException(error.ToString());
+            }
 
-        try
-        {
-            _factory = DataAccessProvider.GetDbProviderFactory(ConnectionProvider);
-        }
-        catch (DataAccessProviderException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            throw new DataAccessException(ex);
-        }
+            try
+            {
+                _factory = DataAccessProvider.GetDbProviderFactory(ConnectionProvider);
+            }
+            catch (DataAccessProviderException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new DataAccessException(ex);
+            }
 
-        return _factory;
+            return _factory;
+        }
     }
 
     public DbConnection GetConnection()
     {
-        var _connection = GetFactory().CreateConnection();
+        var _connection = DbProviderFactory.CreateConnection();
 
         try
         {
@@ -138,7 +142,7 @@ public class DataAccess
 
     public async Task<DbConnection> GetConnectionAsync()
     {
-        var _connection = GetFactory().CreateConnection();
+        var _connection = DbProviderFactory.CreateConnection();
 
         try
         {
@@ -180,7 +184,7 @@ public class DataAccess
 
             using (dbCommand.Connection)
             {
-                using var dataAdapter = GetFactory().CreateDataAdapter();
+                using var dataAdapter = DbProviderFactory.CreateDataAdapter();
                 dataAdapter!.SelectCommand = dbCommand;
                 dataAdapter.Fill(dt);
     
@@ -222,7 +226,7 @@ public class DataAccess
 
             using (dbCommand.Connection)
             {
-                using var dataAdapter = GetFactory().CreateDataAdapter();
+                using var dataAdapter = DbProviderFactory.CreateDataAdapter();
                 dataAdapter!.SelectCommand = dbCommand;
                 dataAdapter.Fill(dt);
 
@@ -254,13 +258,13 @@ public class DataAccess
         var dt = new DataTable();
         try
         {
-            using var dbCommand = GetFactory().CreateCommand();
+            using var dbCommand = DbProviderFactory.CreateCommand();
             dbCommand!.CommandType = CommandType.Text;
             dbCommand.Connection = sqlConn;
             dbCommand.CommandText = sql;
             dbCommand.CommandTimeout = TimeOut;
 
-            using var dataAdapter = GetFactory().CreateDataAdapter();
+            using var dataAdapter = DbProviderFactory.CreateDataAdapter();
             dataAdapter!.SelectCommand = dbCommand;
             dataAdapter.Fill(dt);
         }
@@ -748,7 +752,7 @@ public class DataAccess
         errorMessage = null;
         try
         {
-            connection = GetFactory().CreateConnection();
+            connection = DbProviderFactory.CreateConnection();
             connection!.ConnectionString = ConnectionString;
             connection.Open();
             result = true;
@@ -787,7 +791,7 @@ public class DataAccess
         string errorMessage = null;
         try
         {
-            connection = GetFactory().CreateConnection();
+            connection = DbProviderFactory.CreateConnection();
             connection!.ConnectionString = ConnectionString;
             await connection.OpenAsync();
             result = true;
@@ -929,7 +933,7 @@ public class DataAccess
 
     private DbCommand CreateDbCommand(DataAccessCommand command)
     {
-        var dbCommand = GetFactory().CreateCommand();
+        var dbCommand = DbProviderFactory.CreateCommand();
         if (dbCommand == null)
             throw new ArgumentNullException(nameof(dbCommand));
 
@@ -947,7 +951,7 @@ public class DataAccess
 
     private DbParameter CreateDbParameter(DataAccessParameter parameter)
     {
-        var dbParameter = GetFactory().CreateParameter();
+        var dbParameter = DbProviderFactory.CreateParameter();
         dbParameter!.DbType = parameter.Type;
         dbParameter.Value = parameter.Value ?? DBNull.Value;
         dbParameter.ParameterName = parameter.Name;

--- a/src/JJMasterData.Commons/Dao/Entity/Factory.cs
+++ b/src/JJMasterData.Commons/Dao/Entity/Factory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Data;
 using JJMasterData.Commons.Dao.Providers;
 using JJMasterData.Commons.Language;
@@ -71,7 +72,7 @@ public class Factory : IEntityRepository
     public void SetCommand(string sql) => DataAccess.SetCommand(sql);
 
     ///<inheritdoc cref="IEntityRepository.SetCommand(ArrayList)"/>
-    public int SetCommand(ArrayList sqlList) => DataAccess.SetCommand(sqlList);
+    public int SetCommand(IEnumerable<string> sqlList) => DataAccess.SetCommand(sqlList);
 
     ///<inheritdoc cref="IEntityRepository.TableExists(string)"/>
     public bool TableExists(string tableName) => DataAccess.TableExists(tableName);

--- a/src/JJMasterData.Commons/Dao/Entity/IEntityRepository.cs
+++ b/src/JJMasterData.Commons/Dao/Entity/IEntityRepository.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
 using System.Data;
 using JJMasterData.Commons.Dao.Entity;
 
@@ -197,7 +198,7 @@ public interface IEntityRepository
     /// <remarks>
     /// It's used to run delete scripts
     /// </remarks>
-    public int SetCommand(ArrayList sqlList);
+    public int SetCommand(IEnumerable<string> sqlList);
 
     /// <summary>
     /// Executes a database script.

--- a/src/JJMasterData.Core/JJMasterData.Core.xml
+++ b/src/JJMasterData.Core/JJMasterData.Core.xml
@@ -379,7 +379,7 @@
             Objeto responsável por fazer toda a comunicação com o banco de dados
             </summary>
         </member>
-        <member name="P:JJMasterData.Core.DataDictionary.DataLog.AuditLogService.DbProviderFactory">
+        <member name="P:JJMasterData.Core.DataDictionary.DataLog.AuditLogService.Factory">
             <summary>
             Objeto responsável por traduzir o elemento base em comandos para o banco de dados
             </summary>
@@ -1000,7 +1000,7 @@
             Configurações pré-definidas do formulário
             </summary>
         </member>
-        <member name="P:JJMasterData.Core.DataDictionary.FormManager.DbProviderFactory">
+        <member name="P:JJMasterData.Core.DataDictionary.FormManager.Factory">
             <summary>
             Objeto responsável por traduzir o elemento base em comandos para o banco de dados
             </summary>
@@ -1682,7 +1682,7 @@
             Objeto responsável por fazer toda a comunicação com o banco de dados
             </summary>
         </member>
-        <member name="P:JJMasterData.Core.WebComponents.JJBaseView.DbProviderFactory">
+        <member name="P:JJMasterData.Core.WebComponents.JJBaseView.Factory">
             <summary>
             Objeto responsável por traduzir o elemento base em comandos para o banco de dados
             </summary>

--- a/src/JJMasterData.Core/JJMasterData.Core.xml
+++ b/src/JJMasterData.Core/JJMasterData.Core.xml
@@ -379,7 +379,7 @@
             Objeto responsável por fazer toda a comunicação com o banco de dados
             </summary>
         </member>
-        <member name="P:JJMasterData.Core.DataDictionary.DataLog.AuditLogService.Factory">
+        <member name="P:JJMasterData.Core.DataDictionary.DataLog.AuditLogService.DbProviderFactory">
             <summary>
             Objeto responsável por traduzir o elemento base em comandos para o banco de dados
             </summary>
@@ -1000,7 +1000,7 @@
             Configurações pré-definidas do formulário
             </summary>
         </member>
-        <member name="P:JJMasterData.Core.DataDictionary.FormManager.Factory">
+        <member name="P:JJMasterData.Core.DataDictionary.FormManager.DbProviderFactory">
             <summary>
             Objeto responsável por traduzir o elemento base em comandos para o banco de dados
             </summary>
@@ -1682,7 +1682,7 @@
             Objeto responsável por fazer toda a comunicação com o banco de dados
             </summary>
         </member>
-        <member name="P:JJMasterData.Core.WebComponents.JJBaseView.Factory">
+        <member name="P:JJMasterData.Core.WebComponents.JJBaseView.DbProviderFactory">
             <summary>
             Objeto responsável por traduzir o elemento base em comandos para o banco de dados
             </summary>

--- a/src/JJMasterData.Core/WebComponents/ActionManager.cs
+++ b/src/JJMasterData.Core/WebComponents/ActionManager.cs
@@ -4,11 +4,11 @@ using JJMasterData.Commons.Language;
 using JJMasterData.Commons.Util;
 using JJMasterData.Core.DataDictionary;
 using JJMasterData.Core.DataDictionary.Action;
-using JJMasterData.Core.DataDictionary.Repository;
 using JJMasterData.Core.DataManager;
 using Newtonsoft.Json;
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Text;
 using JJMasterData.Commons.DI;
 using JJMasterData.Core.DI;
@@ -332,7 +332,7 @@ internal class ActionManager
                     var formManager = new FormManager(FormElement, Expression);
                     formValues = formManager.GetDefaultValues(null, PageState.List);
                 }
-                scriptManager.Execute(Expression.ParseExpression(action.PythonScript, PageState.List, false, formValues));
+                scriptManager?.Execute(Expression.ParseExpression(action.PythonScript, PageState.List, false, formValues));
             }
         }
         catch (Exception ex)
@@ -348,7 +348,7 @@ internal class ActionManager
     {
         try
         {
-            var listSql = new ArrayList();
+            var listSql = new List<string>();
             if (map.ContextAction == ActionOrigin.Toolbar && gridView.EnableMultSelect && cmdAction.ApplyOnSelected)
             {
                 var selectedRows = gridView.GetSelectedGridValues();
@@ -360,7 +360,7 @@ internal class ActionManager
 
                 foreach (var row in selectedRows)
                 {
-                    string sql = this.Expression.ParseExpression(cmdAction.CommandSQL, PageState.List, false, row);
+                    string sql = Expression.ParseExpression(cmdAction.CommandSQL, PageState.List, false, row);
                     listSql.Add(sql);
                 }
 


### PR DESCRIPTION
To reproduze: Refresh the page **lot of times** until it crashes. (The new DbLogger logs a lot of things from ASP.NET Core)

Without using:
![Screenshot from 2023-01-16 14-58-54](https://user-images.githubusercontent.com/52143624/212741593-d13cf343-a47b-4b53-bc33-500fd5f2a612.png)

With using: (everything works fine)

Googling I found that ADO.NET already creates a connection pooling system, don't needing the `KeepConnAlive` property.
No breaking changes expected, except in one single place in a private system, but I think this place don't need the `KeepConnAlive` property, you can just send a `IEnumerable<DataAccessCommand>`.
https://stackoverflow.com//questions/3344953/best-practice-open-and-close-multi-connections-or-one-large-open-connection-fo#answer-3345011