### PR TITLE
DataAccess is now correctly created.

### DIFF
--- a/example/JJMasterData.WebExample/Program.cs
+++ b/example/JJMasterData.WebExample/Program.cs
@@ -21,7 +21,10 @@ public class Program
         builder.Services.AddJJMasterDataWeb(settingsPath)
             .WithFormEventResolver()
             .WithPdfExportation();
-            //.WithDataAccess(_=>new DataAccess(builder.Configuration.GetConnectionString("ConnectionString"),"System.Data.SqlClient"));
+            // .WithEntityRepository(
+            //     "data source=localhost,1433;initial catalog=JJMasterData;user=sa;password=Test@123456",
+            //     DataAccessProviderType.SqlServer);
+        //.WithDataAccess(_=>new DataAccess(builder.Configuration.GetConnectionString("ConnectionString"),"System.Data.SqlClient"));
             //.WithMongoDbDataDictionary();
             //.WithPythonFormEventResolver(options => options.ScriptsPath = "../../example/JJMasterData.WebExample/FormEvents/Python");
         

--- a/example/JJMasterData.WebExample/Program.cs
+++ b/example/JJMasterData.WebExample/Program.cs
@@ -1,3 +1,4 @@
+using JJMasterData.Commons.Data;
 using JJMasterData.Core.Extensions;
 using JJMasterData.Web.Extensions;
 using JJMasterData.Pdf;
@@ -20,6 +21,7 @@ public class Program
         builder.Services.AddJJMasterDataWeb(settingsPath)
             .WithFormEventResolver()
             .WithPdfExportation();
+            //.WithDataAccess(_=>new DataAccess(builder.Configuration.GetConnectionString("ConnectionString"),"System.Data.SqlClient"));
             //.WithMongoDbDataDictionary();
             //.WithPythonFormEventResolver(options => options.ScriptsPath = "../../example/JJMasterData.WebExample/FormEvents/Python");
         

--- a/src/JJMasterData.Commons/DI/JJServiceBuilder.cs
+++ b/src/JJMasterData.Commons/DI/JJServiceBuilder.cs
@@ -1,5 +1,7 @@
-﻿using JJMasterData.Commons.Cryptography;
+﻿using System;
+using JJMasterData.Commons.Cryptography;
 using JJMasterData.Commons.Cryptography.Abstractions;
+using JJMasterData.Commons.Data;
 using JJMasterData.Commons.Data.Entity;
 using JJMasterData.Commons.Data.Entity.Abstractions;
 using JJMasterData.Commons.Extensions;
@@ -34,6 +36,7 @@ public class JJServiceBuilder
             }
         });
         
+        Services.AddScoped<DataAccess>();
         Services.AddScoped<IEntityRepository,EntityRepository>();
         
         Services.AddTransient<IEncryptionService, AesEncryptionService>();
@@ -50,7 +53,13 @@ public class JJServiceBuilder
         Services.Replace(ServiceDescriptor.Transient<IBackgroundTask, T>());
         return this;
     }
-
+    
+    public JJServiceBuilder WithDataAccess(Func<IServiceProvider, DataAccess> implementationFactory)
+    {
+        Services.Replace(ServiceDescriptor.Scoped(implementationFactory));
+        return this;
+    }
+    
     public JJServiceBuilder WithLocalizationProvider<T>() where T : class, ILocalizationProvider
     {
         Services.Replace(ServiceDescriptor.Transient<ILocalizationProvider, T>());

--- a/src/JJMasterData.Commons/DI/JJServiceBuilder.cs
+++ b/src/JJMasterData.Commons/DI/JJServiceBuilder.cs
@@ -36,7 +36,6 @@ public class JJServiceBuilder
             }
         });
         
-        Services.AddScoped<DataAccess>();
         Services.AddScoped<IEntityRepository,EntityRepository>();
         
         Services.AddTransient<IEncryptionService, AesEncryptionService>();
@@ -54,7 +53,12 @@ public class JJServiceBuilder
         return this;
     }
     
-    public JJServiceBuilder WithDataAccess(Func<IServiceProvider, DataAccess> implementationFactory)
+    public JJServiceBuilder WithEntityRepository(string connectionString, DataAccessProviderType provider)
+    {
+        return WithEntityRepository(_ => new EntityRepository(connectionString, provider));
+    }
+    
+    public JJServiceBuilder WithEntityRepository(Func<IServiceProvider, EntityRepository> implementationFactory)
     {
         Services.Replace(ServiceDescriptor.Scoped(implementationFactory));
         return this;

--- a/src/JJMasterData.Commons/Data/DataAccess.cs
+++ b/src/JJMasterData.Commons/Data/DataAccess.cs
@@ -99,7 +99,6 @@ public class DataAccess
     /// <summary>
     /// By default DataAccess recover connection string from appsettings.json with name ConnectionString
     /// </summary>
-    [Obsolete("Will be removed at Sun version, this constructor uses a static service locator and can cause runtime errors.")]
     public DataAccess()
     {
         ConnectionString = JJMasterDataCommonsOptions.GetConnectionString();
@@ -110,7 +109,6 @@ public class DataAccess
     /// New instance from a custom connection string name
     /// </summary>
     /// <param name="connectionStringName">Name of connection string in appsettings.json or webconfig.xml file</param>
-    [Obsolete("Will be removed at Sun version, this constructor uses a static service locator and can cause runtime errors.")]
     public DataAccess(string connectionStringName)
     {
         ConnectionString = JJMasterDataCommonsOptions.GetConnectionString(connectionStringName);

--- a/src/JJMasterData.Commons/Data/DataAccess.cs
+++ b/src/JJMasterData.Commons/Data/DataAccess.cs
@@ -12,6 +12,8 @@ using System.Threading.Tasks;
 using JJMasterData.Commons.Exceptions;
 using JJMasterData.Commons.Extensions;
 using JJMasterData.Commons.Options;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace JJMasterData.Commons.Data;
 
@@ -97,6 +99,7 @@ public class DataAccess
     /// <summary>
     /// By default DataAccess recover connection string from appsettings.json with name ConnectionString
     /// </summary>
+    [Obsolete("Will be removed at Sun version, this constructor uses a static service locator and can cause runtime errors.")]
     public DataAccess()
     {
         ConnectionString = JJMasterDataCommonsOptions.GetConnectionString();
@@ -107,6 +110,7 @@ public class DataAccess
     /// New instance from a custom connection string name
     /// </summary>
     /// <param name="connectionStringName">Name of connection string in appsettings.json or webconfig.xml file</param>
+    [Obsolete("Will be removed at Sun version, this constructor uses a static service locator and can cause runtime errors.")]
     public DataAccess(string connectionStringName)
     {
         ConnectionString = JJMasterDataCommonsOptions.GetConnectionString(connectionStringName);
@@ -114,7 +118,7 @@ public class DataAccess
     }
 
     /// <summary>
-    /// Initialize a connectionString with a specific providerName.
+    /// Initialize a with a connectionString and a specific providerName.
     /// See also <see cref="DataAccessProvider"/>.
     /// </summary>
     /// <param name="connectionString">Conections string with data source, user etc...</param>
@@ -124,6 +128,17 @@ public class DataAccess
         ConnectionString = connectionString;
         ConnectionProvider = connectionProviderName;
     }
+    
+    /// <summary>
+    /// Initialize with a IConfiguration instance.
+    /// </summary>
+    [ActivatorUtilitiesConstructor]
+    public DataAccess(IConfiguration configuration)
+    {
+        ConnectionString = configuration.GetConnectionString("ConnectionString");
+        ConnectionProvider = configuration.GetSection("ConnectionProviders").GetValue<string>("ConnectionString") ?? "System.Data.SqlClient";
+    }
+
 
     public DbConnection GetConnection()
     {

--- a/src/JJMasterData.Commons/Data/DataAccessProvider.cs
+++ b/src/JJMasterData.Commons/Data/DataAccessProvider.cs
@@ -71,4 +71,5 @@ public static class DataAccessProvider
         var type = GetDataAccessProviderTypeFromString(providerName);
         return GetDbProviderFactory(type);
     }
+    
 }

--- a/src/JJMasterData.Commons/Data/Entity/EntityRepository.cs
+++ b/src/JJMasterData.Commons/Data/Entity/EntityRepository.cs
@@ -10,30 +10,25 @@ namespace JJMasterData.Commons.Data.Entity;
 
 public class EntityRepository : IEntityRepository
 {
-    private DataAccess _dataAccess;
-    private BaseProvider _provider;
-
-    internal DataAccess DataAccess => _dataAccess ??= new DataAccess();
-
-    internal BaseProvider Provider
+    private DataAccess DataAccess { get; }
+    private BaseProvider Provider { get; }
+    public EntityRepository(DataAccess dataAccess)
     {
-        get
+        DataAccess = dataAccess;
+        Provider = GetProvider();
+    }
+
+    private BaseProvider GetProvider()
+    {
+        return DataAccessProvider.GetDataAccessProviderTypeFromString(DataAccess.ConnectionProvider) switch
         {
-            if (_provider != null) 
-                return _provider;
-
-            _provider = DataAccessProvider.GetDataAccessProviderTypeFromString(DataAccess.ConnectionProvider) switch
-            {
-                DataAccessProviderType.SqlServer => new SqlServerProvider(DataAccess),
-                DataAccessProviderType.Oracle => new OracleProvider(DataAccess),
-                DataAccessProviderType.OracleNetCore => new OracleProvider(DataAccess),
-                DataAccessProviderType.SqLite => new ProviderSQLite(DataAccess),
-                _ => throw new InvalidOperationException(Translate.Key("Invalid data provider.") + " [" +
-                                                         DataAccess.ConnectionProvider + "]")
-            };
-
-            return _provider;
-        }
+            DataAccessProviderType.SqlServer => new SqlServerProvider(DataAccess),
+            DataAccessProviderType.Oracle => new OracleProvider(DataAccess),
+            DataAccessProviderType.OracleNetCore => new OracleProvider(DataAccess),
+            DataAccessProviderType.SqLite => new ProviderSQLite(DataAccess),
+            _ => throw new InvalidOperationException(Translate.Key("Invalid data provider.") + " [" +
+                                                     DataAccess.ConnectionProvider + "]")
+        };
     }
 
     ///<inheritdoc cref="IEntityRepository.Insert(Element, IDictionary)"/>

--- a/src/JJMasterData.Commons/Data/Entity/EntityRepository.cs
+++ b/src/JJMasterData.Commons/Data/Entity/EntityRepository.cs
@@ -4,7 +4,9 @@ using System.Collections.Generic;
 using System.Data;
 using JJMasterData.Commons.Data.Entity.Abstractions;
 using JJMasterData.Commons.Data.Providers;
+using JJMasterData.Commons.Extensions;
 using JJMasterData.Commons.Localization;
+using Microsoft.Extensions.Configuration;
 
 namespace JJMasterData.Commons.Data.Entity;
 
@@ -12,9 +14,19 @@ public class EntityRepository : IEntityRepository
 {
     private DataAccess DataAccess { get; }
     private BaseProvider Provider { get; }
-    public EntityRepository(DataAccess dataAccess)
+    public EntityRepository(IConfiguration configuration)
     {
-        DataAccess = dataAccess;
+        var connectionString = configuration.GetConnectionString("ConnectionString");
+        var connectionProvider = configuration.GetSection("ConnectionProviders").GetValue<string>("ConnectionString");
+        DataAccess = new DataAccess(connectionString, connectionProvider);
+        
+        Provider = GetProvider();
+    }
+    
+    public EntityRepository(string connectionString, DataAccessProviderType provider)
+    {
+        DataAccess = new DataAccess(connectionString, provider.GetDescription());
+        
         Provider = GetProvider();
     }
 

--- a/src/JJMasterData.Core/Extensions/JJServiceBuilderExtensions.cs
+++ b/src/JJMasterData.Core/Extensions/JJServiceBuilderExtensions.cs
@@ -1,17 +1,20 @@
 ﻿#nullable enable
 
 using System;
+using JJMasterData.Commons.Data;
+using JJMasterData.Commons.Data.Entity;
 using JJMasterData.Commons.DI;
-using JJMasterData.Core.DataDictionary;
 using JJMasterData.Core.DataDictionary.Repository;
 using JJMasterData.Core.DataDictionary.Repository.Abstractions;
 using JJMasterData.Core.DataManager;
 using JJMasterData.Core.DataManager.Exports.Abstractions;
 using JJMasterData.Core.FormEvents;
 using JJMasterData.Core.FormEvents.Abstractions;
+using JJMasterData.Core.Options;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 
 namespace JJMasterData.Core.Extensions;
 
@@ -52,9 +55,26 @@ public static class JJServiceBuilderExtensions
         return builder;
     }
     
+    public static JJServiceBuilder WithDataDictionaryRepository(this JJServiceBuilder builder, Func<IServiceProvider, IDataDictionaryRepository> implementationFactory) 
+    {
+        builder.Services.Replace(ServiceDescriptor.Transient(implementationFactory));
+        return builder;
+    }
+    
     public static JJServiceBuilder WithDatabaseDataDictionary(this JJServiceBuilder builder)
     {
         builder.Services.Replace(ServiceDescriptor.Scoped<IDataDictionaryRepository, SqlDataDictionaryRepository>());
+        return builder;
+    }
+    
+    public static JJServiceBuilder WithDatabaseDataDictionary(this JJServiceBuilder builder, string connectionString, DataAccessProviderType provider)
+    {
+        builder.Services.Replace(ServiceDescriptor.Scoped(serviceProvider =>
+        {
+            var entityRepository = new EntityRepository(connectionString, provider);
+            return new SqlDataDictionaryRepository(entityRepository,
+                serviceProvider.GetRequiredService<IOptions<JJMasterDataCoreOptions>>());
+        }));
         return builder;
     }
    

--- a/src/Plugins/JJMasterData.Pdf/PdfWriter.cs
+++ b/src/Plugins/JJMasterData.Pdf/PdfWriter.cs
@@ -16,7 +16,9 @@ using iText.Layout;
 using iText.Layout.Borders;
 using iText.Layout.Element;
 using iText.Layout.Properties;
+using JJMasterData.Commons.Data;
 using JJMasterData.Commons.Data.Entity;
+using JJMasterData.Commons.DI;
 using JJMasterData.Commons.Localization;
 using JJMasterData.Core.DataDictionary;
 using JJMasterData.Core.DataManager.Exports.Abstractions;
@@ -97,7 +99,7 @@ public class PdfWriter : BaseWriter, IPdfWriter
         int tot = 0;
         if (DataSource == null)
         {
-            var factory = new EntityRepository();
+            var factory = JJService.EntityRepository;
             DataSource = factory.GetDataTable(FormElement, CurrentFilter, CurrentOrder, RegPerPag, 1, ref tot);
             ProcessReporter.TotalRecords = tot;
             ProcessReporter.Message = Translate.Key("Exporting {0} records...", tot.ToString("N0"));

--- a/test/JJMasterData.Web.Test/Areas/DataDictionary/Controllers/ElementControllerTest.cs
+++ b/test/JJMasterData.Web.Test/Areas/DataDictionary/Controllers/ElementControllerTest.cs
@@ -44,7 +44,7 @@ public class ElementControllerTest : IClassFixture<JJMasterDataWebExampleAppFact
         };
 
         var dataAccess = new DataAccess();
-        var provider = new EntityRepository();
+        var provider = new EntityRepository(dataAccess);
         
         string script = provider.GetScriptCreateTable(element);
 

--- a/test/JJMasterData.Web.Test/Areas/DataDictionary/Controllers/ElementControllerTest.cs
+++ b/test/JJMasterData.Web.Test/Areas/DataDictionary/Controllers/ElementControllerTest.cs
@@ -44,7 +44,7 @@ public class ElementControllerTest : IClassFixture<JJMasterDataWebExampleAppFact
         };
 
         var dataAccess = new DataAccess();
-        var provider = new EntityRepository(dataAccess);
+        var provider = new EntityRepository("data source=localhost,1433;initial catalog=JJMasterData;user=sa;password=Test@123456", DataAccessProviderType.SqlServer);
         
         string script = provider.GetScriptCreateTable(element);
 


### PR DESCRIPTION
@LucioPelinson .

Currently `DataAccess` is "chumbado" with a ConnectionString named `ConnectionString`.

This solves the problem:
```cs
    public JJServiceBuilder WithDataAccess(Func<IServiceProvider, DataAccess> implementationFactory)
    {
        Services.Replace(ServiceDescriptor.Scoped(implementationFactory));
        return this;
    }
```

This will be merged at `main`, we're needing the fix.
    