### PR TITLE
bugfix: Checkbox value is overriden on postback.

### DIFF
--- a/src/JJMasterData.Core/DataManager/FormValues.cs
+++ b/src/JJMasterData.Core/DataManager/FormValues.cs
@@ -62,7 +62,7 @@ internal class FormValues
                     }
                     break;
                 case FormComponent.CheckBox:
-                    value ??= CurrentContext.Request.Form(fieldName + "_hidden") ?? "0";
+                    value ??= CurrentContext.Request.Form(fieldName + "_hidden");
                     break;
             }
 


### PR DESCRIPTION
Removed this:
![Uploading image.png…]()

Because of this:
```cs
        return _formManager.MergeWithExpressionValues(newValues, state, !CurrentContext.IsPostBack);
```

The database value is overriden by a non-existent form value.