### PR TITLE
Remove reflection from FormEvents at runtime

### DIFF
--- a/src/Core/Configuration/EventHandlerServiceExtensions.cs
+++ b/src/Core/Configuration/EventHandlerServiceExtensions.cs
@@ -1,5 +1,10 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using JJMasterData.Commons.Util;
 using JJMasterData.Core.DataDictionary.FormEvents;
 using JJMasterData.Core.FormEvents.Abstractions;
+using JJMasterData.Core.Web.FormEvents.Abstractions;
 using JJMasterData.Core.Web.FormEvents.Factories;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -11,6 +16,27 @@ public static class EventHandlerServiceExtensions
     {
         services.AddTransient<IFormEventHandlerFactory,FormEventHandlerFactory>();
         services.AddTransient<IGridEventHandlerFactory,GridEventHandlerFactory>();
+
+        services.AddEventHandlers<IFormEventHandler>();
+        services.AddEventHandlers<IGridEventHandler>();
+        
+        return services;
+    }
+
+    private static IServiceCollection AddEventHandlers<T>(this IServiceCollection services) where T : IEventHandler
+    {
+        var assemblies = new List<Assembly>
+        {
+            Assembly.GetEntryAssembly(),
+            typeof(EventHandlerServiceExtensions).Assembly
+        };
+        
+        var types = ReflectionUtils.GetDefinedTypes<T>(assemblies);
+
+        foreach (var formEventHandlerType in types.Where(t=>!t.IsAbstract))
+        {
+            services.Add(new ServiceDescriptor(typeof(T), formEventHandlerType, ServiceLifetime.Transient));
+        }
 
         return services;
     }

--- a/src/Core/Events/FormEventHandlerFactory.cs
+++ b/src/Core/Events/FormEventHandlerFactory.cs
@@ -1,14 +1,12 @@
-using JetBrains.Annotations;
+using System.Collections.Generic;
 using JJMasterData.Core.FormEvents;
 using JJMasterData.Core.FormEvents.Abstractions;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 
 namespace JJMasterData.Core.DataDictionary.FormEvents;
 
 public class FormEventHandlerFactory : EventHandlerFactoryBase<IFormEventHandler>, IFormEventHandlerFactory
 {
-    public FormEventHandlerFactory(IOptions<EventHandlerFactoryOptions> options,IServiceScopeFactory serviceScopeFactory) : base(options, serviceScopeFactory)
+    public FormEventHandlerFactory(IEnumerable<IFormEventHandler> eventHandlers) : base(eventHandlers)
     {
     }
 

--- a/src/Core/UI/Components/FormView/FormViewFactory.cs
+++ b/src/Core/UI/Components/FormView/FormViewFactory.cs
@@ -75,27 +75,35 @@ internal class FormViewFactory : IFormElementComponentFactory<JJFormView>
             Options,
             StringLocalizer,
             Factory);
+        
+        SetFormEventHandler(formView, formElement);
+        
         return formView;
     }
 
     public async Task<JJFormView> CreateAsync(string elementName)
     {
         var formElement = await DataDictionaryRepository.GetMetadataAsync(elementName);
-        var form = Create(formElement);
-        await SetFormViewParamsAsync(form, formElement);
-        return form;
+        var formView = Create(formElement);
+        await SetFormEventHandlerAsync(formView, formElement);
+        return formView;
     }
 
-    internal async Task SetFormViewParamsAsync(JJFormView formView, FormElement formElement)
+    private void SetFormEventHandler(JJFormView formView, FormElement formElement)
+    {
+        var formEventHandler = FormEventHandlerFactory.GetFormEvent(formElement.Name);
+        formView.FormService.AddFormEventHandler(formEventHandler);
+
+        formEventHandler?.OnFormElementLoad(this, new FormElementLoadEventArgs(formElement));
+    }
+    
+    internal async Task SetFormEventHandlerAsync(JJFormView formView, FormElement formElement)
     {
         var formEventHandler = FormEventHandlerFactory.GetFormEvent(formElement.Name);
         formView.FormService.AddFormEventHandler(formEventHandler);
 
         if (formEventHandler != null)
         {
-            // ReSharper disable once MethodHasAsyncOverload
-            formEventHandler.OnFormElementLoad(this, new FormElementLoadEventArgs(formElement));
-                    
             await formEventHandler.OnFormElementLoadAsync(this, new FormElementLoadEventArgs(formElement))!;
         }
     }

--- a/src/Core/UI/Components/FormView/JJFormView.cs
+++ b/src/Core/UI/Components/FormView/JJFormView.cs
@@ -297,7 +297,7 @@ public class JJFormView : AsyncComponent
         var dataDictionaryRepository = StaticServiceLocator.Provider.GetScopedDependentService<IDataDictionaryRepository>();
         var factory = StaticServiceLocator.Provider.GetScopedDependentService<FormViewFactory>();
         FormElement = dataDictionaryRepository.GetMetadataAsync(elementName).GetAwaiter().GetResult();
-        factory.SetFormViewParamsAsync(this, FormElement).GetAwaiter().GetResult();
+        factory.SetFormEventHandlerAsync(this, FormElement).GetAwaiter().GetResult();
     }
 
     public JJFormView(FormElement formElement) : this()

--- a/src/Core/UI/Events/Factories/GridEventHandlerFactory.cs
+++ b/src/Core/UI/Events/Factories/GridEventHandlerFactory.cs
@@ -1,19 +1,12 @@
 using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using JetBrains.Annotations;
-using JJMasterData.Commons.Util;
 using JJMasterData.Core.FormEvents;
-using JJMasterData.Core.FormEvents.Abstractions;
 using JJMasterData.Core.Web.FormEvents.Abstractions;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 
 namespace JJMasterData.Core.Web.FormEvents.Factories;
 
 public class GridEventHandlerFactory : EventHandlerFactoryBase<IGridEventHandler>, IGridEventHandlerFactory
 {
-    public GridEventHandlerFactory(IOptions<EventHandlerFactoryOptions> options, IServiceScopeFactory serviceScopeFactory) : base(options, serviceScopeFactory)
+    public GridEventHandlerFactory(IEnumerable<IGridEventHandler> eventHandlers) : base(eventHandlers)
     {
     }
     


### PR DESCRIPTION
Use reflection to inject the FormEvents, not to instantiate at runtime.