### PR TITLE
Added Expression Tag Helper 

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -29,11 +29,11 @@
     },
     "File": {
       "LogLevel": {
-        "Default": "Debug",
-        "Microsoft.AspNetCore": "Debug"
+        "Default": "Error",
+        "Microsoft.AspNetCore": "None"
       },
-      "FileName": "Log/AppLog-yyyyMMdd_JSON_hosted.json",
-      "Formatting": "Json"
+      "FileName": "/home/gumbarros/Documents/JJMasterData/Log/AppLog_yyyyMMdd.txt",
+      "Formatting": "Compact"
     }
   }
 }

--- a/doc/Documentation/articles/expressions.md
+++ b/doc/Documentation/articles/expressions.md
@@ -3,12 +3,9 @@
 ## What is a expression?
 Expression is a simple way to return a dynamic value.
 
-
 ## How it works?
 
 Expressions can return a boolean or a value at runtime<br>
- - Tipo [val] retorna um valor; 
- - Tipo [exp] retorna o resultado da expressão; 
 Example: <br>
 
 "val:1" Return true.
@@ -20,11 +17,10 @@ Example: <br>
 "exp:{pagestate} = 'LIST'" If a list return true<br>
 "exp:{pagestate} = 'UPDATE' AND {ID} = '1'" If update and a field value ID equals 1 return true<br>
 
-## What is the types of expressions?
+## What are the default expression providers?
 - Type [val:] returns a value; (1 or 0) (true or false) ("foo") etc..
-- Type [exp:] returns the result of the expression;
+- Type [exp:] returns the result of the expression from `DataTable.Compute`;
 - Type [sql:] returns the result of a sql command;
-- Type [protheus:] returns the result of a TOTVS ERP Protheus function;
 
 > [!TIP] 
 > Check if your field supports all expressions
@@ -37,16 +33,15 @@ Building an expression<br>
 
 
 **System keywords**<br>
-{pagestate} = "INSERT" | "UPDATE" | "VIEW" | "LIST" | "FILTER" | "IMPORT"
-<br>
-Form fields, UserValues ou Sessão = {FieldName}
-<br>
-{objname} = Name of the field that triggered the autopostback event
+- {PageState} = "INSERT" | "UPDATE" | "VIEW" | "LIST" | "FILTER" | "IMPORT"
+- {ComponentName} = Name of the component that triggered the AutoPostBack event
+- {UserId} = Identifier of the authenticated user
 
-1. UserValues (propriedade do objeto)
-2. Form Fields (Field Name)
+Dynamic values will be recovered in the following order:
+1. UserValues
+2. FormValues
 3. System keywords
-4. User Session
+4. UserSession
 
 
 ## Examples
@@ -75,6 +70,22 @@ var field = new ElementField();
 field.DefaultValue = "sql:select field2 from table1 where field1 = '{field1}'";
 ```
 
+## Implementing your own expression provider
+
+Implement the [IExpressionProvider](https://portal.jjconsulting.com.br/jjdoc/lib/JJMasterData.Core.Expressions.Abstractions.IExpressionProvider.html) interface and add to your services your custom provider.
+
+```cs
+builder.Services.AddJJMasterDataWeb().WithExpressionProvider<TMyCustomProvider>();
+//or
+
+```
+
+## Protheus Plugin
+
+Add to your project:
+```cs
+    builder.Services.AddJJMasterDataWeb().WithProtheusServices();
+```
 Example using [protheus:] + "UrlProtheus", "NameFunction", "Parameters" <br>
 1. protheus:"http://localhost/jjmain.apw","u_test","";
 2. protheus:"http://localhost/jjmain.apw","u_test","{field1};parm2";

--- a/doc/Documentation/articles/getting_started.md
+++ b/doc/Documentation/articles/getting_started.md
@@ -14,11 +14,8 @@ In your configuration file (normally appsettings.json), add a SQL Server connect
 ```json
 {
   "AllowedHosts": "*",
-  "ConnectionStrings": {
+  "JJMasterData": {
     "ConnectionString": "data source=localhost,1433;initial catalog=JJMasterData;Integrated Security=True"
-  },
-  "ConnectionProviders": {
-    "ConnectionString": "System.Data.SqlClient"
   }
 }
 ```

--- a/example/WebEntryPoint/Program.cs
+++ b/example/WebEntryPoint/Program.cs
@@ -20,8 +20,6 @@ builder.Services.AddJJMasterDataWeb(builder.Configuration)
         options.AddCssBundle("/css/bootstrap.min.css", "css/bootstrap/bootstrap.css").MinifyCss();
     });
 
-builder.Services.AddControllersWithViews().AddViewLocalization();
-
 if (authentication == "ReportPortal")
 {
     builder.Services.AddAuthentication().WithReportPortal();

--- a/src/Commons/Data/Entity/Models/ElementField.cs
+++ b/src/Commons/Data/Entity/Models/ElementField.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using JJMasterData.Core.DataDictionary.Models;
 using Newtonsoft.Json;
 
@@ -68,6 +70,7 @@ public class ElementField
     /// </remarks>
     [JsonProperty("defaultvalue")]
     [Expression]
+    [Display(Name = "Default Value Expression")]
     public string? DefaultValue { get; set; }
 
     /// <summary>

--- a/src/Commons/Data/Entity/Models/ElementField.cs
+++ b/src/Commons/Data/Entity/Models/ElementField.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 
+using JJMasterData.Core.DataDictionary.Models;
 using Newtonsoft.Json;
 
 namespace JJMasterData.Commons.Data.Entity.Models;
@@ -66,6 +67,7 @@ public class ElementField
     /// [See expressions](../articles/expressions.md)
     /// </remarks>
     [JsonProperty("defaultvalue")]
+    [Expression]
     public string? DefaultValue { get; set; }
 
     /// <summary>

--- a/src/Commons/Data/Entity/Models/ExpressionAttribute.cs
+++ b/src/Commons/Data/Entity/Models/ExpressionAttribute.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace JJMasterData.Core.DataDictionary.Models;
+
+[AttributeUsage(AttributeTargets.Property)]
+public class ExpressionAttribute : Attribute
+{
+    
+}

--- a/src/Commons/Localization/JJMasterDataResources.pt-BR.resx
+++ b/src/Commons/Localization/JJMasterDataResources.pt-BR.resx
@@ -3453,4 +3453,7 @@
   <data name="File is too big. Max file size: {0} mb" xml:space="preserve">
     <value>Arquivo é muito grande. Tamanho máximo {0} mb</value>
   </data>
+  <data name="Default Value Expression" xml:space="preserve">
+    <value>Expressão do Valor Padrão</value>
+  </data>
 </root>

--- a/src/Core/Configuration/FactoriesServiceExtensions.cs
+++ b/src/Core/Configuration/FactoriesServiceExtensions.cs
@@ -43,6 +43,7 @@ public static class FactoriesServiceExtensions
         services.AddScoped<IComponentFactory<JJUploadArea>, UploadAreaFactory>();
         services.AddScoped<IComponentFactory<JJCollapsePanel>, CollapsePanelFactory>();
         services.AddScoped<IComponentFactory<JJLinkButton>,LinkButtonFactory>();
+        services.AddScoped<IComponentFactory<JJCard>, CardFactory>();
         services.AddScoped<RouteContextFactory>();
         services.AddScoped<ValidationSummaryFactory>();
         services.AddScoped<HtmlComponentFactory>();

--- a/src/Core/DataDictionary/Models/FormElementField.cs
+++ b/src/Core/DataDictionary/Models/FormElementField.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using JJMasterData.Commons.Data.Entity.Models;
 using JJMasterData.Core.DataDictionary.Models.Actions;
 using Newtonsoft.Json;
@@ -31,6 +32,7 @@ public class FormElementField : ElementField
     /// [See expressions](../articles/expressions.md)
     /// </remarks>
     [JsonProperty("visibleExpression")]
+    [Display(Name = "Visible Expression")]
     [Expression]
     public string VisibleExpression { get; set; }
 
@@ -38,6 +40,7 @@ public class FormElementField : ElementField
     /// [See expressions](../articles/expressions.md)
     /// </remarks>
     [JsonProperty("enableExpression")]
+    [Display(Name = "Enable Expression")]
     [Expression]
     public string EnableExpression { get; set; }
     
@@ -131,6 +134,7 @@ public class FormElementField : ElementField
     /// [See expressions](../articles/expressions.md)
     /// </remarks>
     [JsonProperty("triggerExpression")]
+    [Display(Name = "Trigger Expression")]
     [Expression]
     public string? TriggerExpression { get; set; }
 

--- a/src/Core/DataDictionary/Models/FormElementField.cs
+++ b/src/Core/DataDictionary/Models/FormElementField.cs
@@ -31,15 +31,16 @@ public class FormElementField : ElementField
     /// [See expressions](../articles/expressions.md)
     /// </remarks>
     [JsonProperty("visibleExpression")]
+    [Expression]
     public string VisibleExpression { get; set; }
 
     /// <remarks>
     /// [See expressions](../articles/expressions.md)
     /// </remarks>
     [JsonProperty("enableExpression")]
+    [Expression]
     public string EnableExpression { get; set; }
     
-
     /// <summary>
     /// Line counter, used to break the line in the form (row class)
     /// </summary>
@@ -130,6 +131,7 @@ public class FormElementField : ElementField
     /// [See expressions](../articles/expressions.md)
     /// </remarks>
     [JsonProperty("triggerExpression")]
+    [Expression]
     public string? TriggerExpression { get; set; }
 
     /// <summary>

--- a/src/Core/DataDictionary/Models/FormUI.cs
+++ b/src/Core/DataDictionary/Models/FormUI.cs
@@ -14,13 +14,13 @@ public class FormUI
     /// Somente multiplos de 12
     /// </remarks>
     [JsonProperty("formCols")]
-    public int FormCols { get; set; }
+    public int FormCols { get; set; } = 1;
 
     /// <summary>
     /// Tipo de layout para renderizar os campos
     /// </summary>
     [JsonProperty("isVerticalLayout")]
-    public bool IsVerticalLayout { get; set; }
+    public bool IsVerticalLayout { get; set; } = true;
 
     /// <summary>
     /// Quando o painel estiver no modo de visualização
@@ -37,13 +37,5 @@ public class FormUI
     /// Default = DISABLED
     /// </summary>
     [JsonProperty("enterKey")]
-    public FormEnterKey EnterKey { get; set; }
-
-    public FormUI()
-    {
-        IsVerticalLayout = true;
-        FormCols = 1;
-        EnterKey = FormEnterKey.Disabled;
-    }
-
+    public FormEnterKey EnterKey { get; set; } = FormEnterKey.Disabled;
 }

--- a/src/Core/DataManager/Expressions/Abstractions/IExpressionProvider.cs
+++ b/src/Core/DataManager/Expressions/Abstractions/IExpressionProvider.cs
@@ -6,5 +6,6 @@ namespace JJMasterData.Core.DataManager.Expressions.Abstractions;
 public interface IExpressionProvider
 {
     string Prefix { get; }
+    string Title { get; }
     Task<object> EvaluateAsync(string expression, FormStateData formStateData);
 }

--- a/src/Core/DataManager/Expressions/ExpressionParser.cs
+++ b/src/Core/DataManager/Expressions/ExpressionParser.cs
@@ -2,6 +2,7 @@
 using JJMasterData.Commons.Util;
 using JJMasterData.Core.DataManager.Models;
 using JJMasterData.Core.Http.Abstractions;
+using Microsoft.Extensions.Logging;
 
 namespace JJMasterData.Core.DataManager.Expressions;
 
@@ -9,12 +10,14 @@ namespace JJMasterData.Core.DataManager.Expressions;
 public class ExpressionParser
 {
     private IHttpContext HttpContext { get; }
+    private ILogger<ExpressionParser> Logger { get; }
     private IHttpRequest Request => HttpContext.Request;
     private IHttpSession Session => HttpContext.Session;
     
-    public ExpressionParser(IHttpContext httpContext)
+    public ExpressionParser(IHttpContext httpContext, ILogger<ExpressionParser> logger)
     {
         HttpContext = httpContext;
+        Logger = logger;
     }
     
     public string? ParseExpression(
@@ -85,6 +88,8 @@ public class ExpressionParser
             parsedExpression = parsedExpression.Replace($"{interval.Begin}{field}{interval.End}", parsedValue);
         }
 
+        Logger.LogDebug("Parsed expression: {ParsedExpression}", expression);
+        
         return parsedExpression;
     }
 }

--- a/src/Core/DataManager/Expressions/ExpressionsService.cs
+++ b/src/Core/DataManager/Expressions/ExpressionsService.cs
@@ -64,6 +64,7 @@ public class ExpressionsService
         
         try
         {
+            Logger.LogDebug("Executing expression: {Expression}", expression);
             result = await provider.EvaluateAsync(expression, formStateData);
         }
 

--- a/src/Core/DataManager/Expressions/Providers/InMemoryExpressionProvider.cs
+++ b/src/Core/DataManager/Expressions/Providers/InMemoryExpressionProvider.cs
@@ -15,7 +15,8 @@ public class InMemoryExpressionProvider : IExpressionProvider
     }
     
     public string Prefix => "exp";
-
+    public string Title => "Expression";
+    
     public async Task<object> EvaluateAsync(string expression, FormStateData formStateData)
     {
         var parsedExpression = _expressionParser.ParseExpression(expression, formStateData, true);

--- a/src/Core/DataManager/Expressions/Providers/SqlExpressionProvider.cs
+++ b/src/Core/DataManager/Expressions/Providers/SqlExpressionProvider.cs
@@ -18,7 +18,8 @@ public class SqlExpressionProvider : IExpressionProvider
     }
 
     public string Prefix => "sql";
-
+    public string Title => "T-SQL";
+    
     public async Task<object> EvaluateAsync(string expression, FormStateData formStateData)
     {
         var parsedSql = _expressionParser.ParseExpression(expression, formStateData, false);

--- a/src/Core/DataManager/Expressions/Providers/ValueExpressionProvider.cs
+++ b/src/Core/DataManager/Expressions/Providers/ValueExpressionProvider.cs
@@ -14,7 +14,7 @@ public class ValueExpressionProvider : IExpressionProvider
     }
 
     public string Prefix => "val";
-
+    public string Title => "Value";
     public async Task<object> EvaluateAsync(string expression, FormStateData formStateData)
     {
         if (expression.Contains("{"))

--- a/src/Core/UI/Components/Controls/CheckBox/JJCheckBox.cs
+++ b/src/Core/UI/Components/Controls/CheckBox/JJCheckBox.cs
@@ -73,7 +73,7 @@ public class JJCheckBox : ControlBase
         
         div.Append(HtmlTag.Input, input =>
         {
-            var checkboxHelperScript = $"CheckboxHelper.check('{Name}', '{Value}')";
+            var checkboxHelperScript = $"CheckboxHelper.check('{Name}')";
             
             if (Attributes.ContainsKey("onchange"))
             {

--- a/src/Core/UI/Components/Controls/ComboBox/JJComboBox.cs
+++ b/src/Core/UI/Components/Controls/ComboBox/JJComboBox.cs
@@ -73,7 +73,7 @@ public class JJComboBox : ControlBase
 
         var values = await GetValuesAsync().ToListAsync();
 
-        if (ReadOnly)
+        if (ReadOnly && Enabled)
         {
             var combobox = new HtmlBuilder(HtmlTag.Div);
             combobox.AppendRange(GetReadOnlyInputs(values));

--- a/src/Core/UI/Components/Controls/TextBox/TextGroupFactory.cs
+++ b/src/Core/UI/Components/Controls/TextBox/TextGroupFactory.cs
@@ -59,11 +59,11 @@ internal class TextGroupFactory : IControlFactory<JJTextGroup>
 
         textGroup.Text = value?.ToString() ?? string.Empty;
 
-        if (formStateData.PageState == PageState.Filter)
+        if (formStateData.PageState is PageState.Filter)
             textGroup.Actions = textGroup.Actions.Where(a => a.ShowInFilter).ToList();
         else
             AddUserActions(formElement, field, context, textGroup).GetAwaiter().GetResult();
-
+        
         return textGroup;
     }
 
@@ -75,8 +75,7 @@ internal class TextGroupFactory : IControlFactory<JJTextGroup>
                                 JJTextGroup textGroup)
     {
         var actions = field.Actions.GetAllSorted().FindAll(x => x.IsVisible);
-
-
+        
         foreach (var action in actions)
         {
             var actionContext = new ActionContext
@@ -89,6 +88,7 @@ internal class TextGroupFactory : IControlFactory<JJTextGroup>
             };
 
             var link = await ActionButtonFactory.CreateFieldButtonAsync(action,actionContext);
+            
             textGroup.Actions.Add(link);
         }
     }
@@ -184,7 +184,7 @@ internal class TextGroupFactory : IControlFactory<JJTextGroup>
                     "'mask': '[(99) 99999-9999]', 'placeholder':'', 'greedy': 'false'");
                 break;
             case FormComponent.Hour:
-                var btn = GetDateAction();
+                var btn = GetDateAction(textGroup.Enabled);
                 btn.IconClass = "fa fa-clock";
                 textGroup.Actions.Add(btn);
 
@@ -197,7 +197,7 @@ internal class TextGroupFactory : IControlFactory<JJTextGroup>
                 break;
             case FormComponent.Date:
                 textGroup.GroupCssClass = "flatpickr date jjform-date";
-                textGroup.Actions.Add(GetDateAction());
+                textGroup.Actions.Add(GetDateAction(textGroup.Enabled));
                 textGroup.InputType = InputType.Text;
                 textGroup.MaxLength = 10;
                 // textGroup.SetAttr("data-inputmask",
@@ -206,7 +206,7 @@ internal class TextGroupFactory : IControlFactory<JJTextGroup>
                 break;
             case FormComponent.DateTime:
                 textGroup.GroupCssClass = "flatpickr date jjform-datetime";
-                textGroup.Actions.Add(GetDateAction());
+                textGroup.Actions.Add(GetDateAction(textGroup.Enabled));
                 textGroup.InputType = InputType.Text;
                 textGroup.MaxLength = 19;
                 // textGroup.SetAttr("data-inputmask",
@@ -221,13 +221,13 @@ internal class TextGroupFactory : IControlFactory<JJTextGroup>
         textGroup.SetAttr("class", string.Join(" ", listClass));
     }
 
-    private JJLinkButton GetDateAction()
+    private JJLinkButton GetDateAction(bool isEnabled)
     {
         var btn = ActionButtonFactory.Create();
         btn.IconClass = $"fa fa-{BootstrapHelper.DateIcon}";
         btn.Tooltip = StringLocalizer["Calendar"];
         btn.ShowInFilter = true;
-
+        btn.Enabled = isEnabled;
         btn.SetAttr("data-toggle", "date");
         btn.SetAttr("tabindex", "-1");
         return btn;

--- a/src/Core/UI/Components/DataPanel/DataPanelControl.cs
+++ b/src/Core/UI/Components/DataPanel/DataPanelControl.cs
@@ -316,15 +316,15 @@ internal class DataPanelControl
         control.Enabled = await ExpressionsService.GetBoolValueAsync(field.EnableExpression, formStateData);
 
         if (BootstrapHelper.Version > 3 && Errors.ContainsKey(field.Name))
-        {
             control.CssClass = "is-invalid";
-        }
 
         if (field.AutoPostBack && PageState is PageState.Insert or PageState.Update)
-        {
             control.SetAttr("onchange", GetScriptReload(field));
-        }
 
+        if(control is JJTextGroup textGroup && PageState is PageState.View)
+            foreach (var textGroupAction in textGroup.Actions)
+                textGroupAction.Enabled = false;
+        
         if (PageState != PageState.Filter) 
             return await control.GetHtmlBuilderAsync();
         
@@ -332,9 +332,9 @@ internal class DataPanelControl
         {
             case JJTextGroup when field.Filter.Type is not (FilterMode.MultValuesContain or FilterMode.MultValuesEqual):
                 return await control.GetHtmlBuilderAsync();
-            case JJTextGroup textGroup:
-                textGroup.Attributes.Add("data-role", "tagsinput");
-                textGroup.MaxLength = 0;
+            case JJTextGroup:
+                control.Attributes.Add("data-role", "tagsinput");
+                control.MaxLength = 0;
                 break;
             case JJComboBox comboBox:
             {
@@ -357,7 +357,7 @@ internal class DataPanelControl
 
         var reloadPanelScript = Scripts.GetReloadPanelScript(field.Name);
         
-        //Workarround to trigger event on search component
+        //Workaround to trigger event on search component
         if (field.Component is not FormComponent.Search) 
             return reloadPanelScript;
         

--- a/src/Core/UI/Components/FormView/FormViewRelationshipLayout.cs
+++ b/src/Core/UI/Components/FormView/FormViewRelationshipLayout.cs
@@ -114,15 +114,18 @@ internal class FormViewRelationshipLayout
 
                 return panel.GetHtmlBuilder();
             case PanelLayout.NoDecoration:
-                var htmlTitle = new JJTitle
-                {
-                    Title = relationship.Panel.Title,
-                    Size = HeadingSize.H3
-                };
-
+                var title = relationship.Panel.Title;
                 var div = new HtmlBuilder(HtmlTag.Div);
                 div.WithCssClass(relationship.Panel.CssClass);
-                div.AppendComponent(htmlTitle);
+                if (title is not null)
+                {       
+                    var htmlTitle = new JJTitle
+                    {
+                        Title = relationship.Panel.Title,
+                        Size = HeadingSize.H3
+                    };
+                    div.AppendComponent(htmlTitle);
+                }
                 div.Append(content);
 
                 return div;

--- a/src/Core/UI/Components/Html/Card/JJCard.cs
+++ b/src/Core/UI/Components/Html/Card/JJCard.cs
@@ -1,4 +1,5 @@
-﻿using JJMasterData.Core.DataDictionary.Models;
+﻿using JetBrains.Annotations;
+using JJMasterData.Core.DataDictionary.Models;
 using JJMasterData.Core.UI.Html;
 
 namespace JJMasterData.Core.UI.Components;
@@ -9,7 +10,7 @@ namespace JJMasterData.Core.UI.Components;
 public class JJCard : HtmlComponent
 {
     public string Title { get; set; }
-
+    
     public string SubTitle { get; set; }
 
     public PanelLayout Layout { get; set; }
@@ -22,7 +23,7 @@ public class JJCard : HtmlComponent
 
     internal JJCard()
     {
-        
+        HtmlBuilderContent = new HtmlBuilder();
     }
     
     internal override HtmlBuilder BuildHtml()

--- a/src/Core/UI/Components/Html/Card/JJCard.cs
+++ b/src/Core/UI/Components/Html/Card/JJCard.cs
@@ -1,4 +1,5 @@
 ﻿using JetBrains.Annotations;
+using JJMasterData.Core.DataDictionary;
 using JJMasterData.Core.DataDictionary.Models;
 using JJMasterData.Core.UI.Html;
 
@@ -20,6 +21,8 @@ public class JJCard : HtmlComponent
     public HtmlBuilder HtmlBuilderContent { get; set; }
 
     private bool HasTitle => !string.IsNullOrEmpty(Title) | !string.IsNullOrEmpty(SubTitle);
+    
+    public IconType? Icon { get; set; }
 
     internal JJCard()
     {
@@ -55,6 +58,12 @@ public class JJCard : HtmlComponent
         html.AppendIf(!string.IsNullOrEmpty(Title), HtmlTag.Div, header =>
         {
             header.WithCssClass(BootstrapHelper.GetPanelHeading(Color.ToString().ToLower()));
+            if (Icon is not null)
+            {
+                var icon = new JJIcon(Icon.Value);
+                icon.CssClass += $" {BootstrapHelper.MarginRight}-1";
+                header.AppendComponent(icon);
+            }
             header.AppendText(Title);
         });
 
@@ -82,6 +91,13 @@ public class JJCard : HtmlComponent
             .WithNameAndId(Name)
             .WithCssClass(CssClass);
 
+        if (Icon is not null)
+        {
+            var icon = new JJIcon(Icon.Value);
+            icon.CssClass += $" {BootstrapHelper.MarginRight}-1";
+            html.AppendComponent(icon);
+        }
+        
         if (HasTitle)
         {
             var title = new JJTitle
@@ -107,6 +123,14 @@ public class JJCard : HtmlComponent
 
         html.WithCssClass(BootstrapHelper.Version == 3 ? "well" : "card card-body bg-light");
 
+        
+        if (Icon is not null)
+        {
+            var icon = new JJIcon(Icon.Value);
+            icon.CssClass += $" {BootstrapHelper.MarginRight}-1";
+            html.AppendComponent(icon);
+        }
+        
         if (HasTitle)
         {
             var title = new JJTitle

--- a/src/Core/UI/Components/Html/CollapsePanel/JJCollapsePanel.cs
+++ b/src/Core/UI/Components/Html/CollapsePanel/JJCollapsePanel.cs
@@ -52,6 +52,7 @@ public class JJCollapsePanel : HtmlComponent
         Buttons = new List<JJLinkButton>();
         Color = PanelColor.Default;
         TitleIcon = null;
+        HtmlBuilderContent = new HtmlBuilder();
     }
 
     internal override HtmlBuilder BuildHtml()

--- a/src/Core/UI/Html/HtmlBuilder.Children.cs
+++ b/src/Core/UI/Html/HtmlBuilder.Children.cs
@@ -136,7 +136,7 @@ public partial class HtmlBuilder
     }
 
     /// <summary>
-    /// Append a hidden input to the Element tree.
+    /// Append a hidden input to the element tree.
     /// </summary>
     public HtmlBuilder AppendHiddenInput(string name, string value)
     {
@@ -149,7 +149,7 @@ public partial class HtmlBuilder
     }
 
     /// <summary>
-    /// Append a hidden input to the Element tree.
+    /// Append a hidden input to the element tree.
     /// </summary>
     public HtmlBuilder AppendHiddenInput(string name)
     {

--- a/src/Core/UI/Html/HtmlBuilder.Children.cs
+++ b/src/Core/UI/Html/HtmlBuilder.Children.cs
@@ -181,7 +181,7 @@ public partial class HtmlBuilder
     }
 
     /// <summary>
-    /// Insert a JJ component as a child of caller builder.
+    /// Insert a HTMLComponent as a child of caller builder.
     /// </summary>
     public HtmlBuilder AppendComponent(HtmlComponent? component)
     {

--- a/src/Plugins/Protheus/ProtheusExpressionProvider.cs
+++ b/src/Plugins/Protheus/ProtheusExpressionProvider.cs
@@ -18,7 +18,7 @@ public class ProtheusExpressionProvider : IExpressionProvider
     }
 
     public string Prefix => "protheus";
-    
+    public string Title => "URL Protheus";
     public async Task<object> EvaluateAsync(string expression, FormStateData formStateData)
     {
         var exp = expression.Replace("\"", "").Replace("'", "").Split(',');

--- a/src/Web/Areas/DataDictionary/Views/Actions/SqlCommandAction.cshtml
+++ b/src/Web/Areas/DataDictionary/Views/Actions/SqlCommandAction.cshtml
@@ -17,7 +17,6 @@
     <script src="~/_content/JJMasterData.Web/js/codemirror/lib/codemirror.js" type="text/javascript"></script>
     <script src="~/_content/JJMasterData.Web/js/codemirror/mode/sql.js" type="text/javascript"></script>
     <script src="~/_content/JJMasterData.Web/js/codemirror/addon/hint/show-hint.js" type="text/javascript"></script>
-    <script src="~/_content/JJMasterData.Web/js/codemirror/addon/autorefresh/autorefresh.js" type="text/javascript"></script>
     <script src="~/_content/JJMasterData.Web/js/codemirror/addon/hint/sql-hint.js" type="text/javascript"></script>
 
     <script lang="javascript" type="text/javascript">

--- a/src/Web/Areas/DataDictionary/Views/Field/Index.cshtml
+++ b/src/Web/Areas/DataDictionary/Views/Field/Index.cshtml
@@ -73,7 +73,7 @@
     <script src="~/_content/JJMasterData.Web/js/codemirror/mode/sql.js" type="text/javascript"></script>
     <script src="~/_content/JJMasterData.Web/js/codemirror/addon/hint/show-hint.js" type="text/javascript"></script>
     <script src="~/_content/JJMasterData.Web/js/codemirror/addon/hint/sql-hint.js" type="text/javascript"></script>
-    
+
     <script type="text/javascript">
          function setupCodeMirror(){
             CodeMirrorWrapper.setupCodeMirror("DataItem_Command_Sql",{
@@ -93,9 +93,11 @@
             
             tabs.forEach((tab)=>{
                  tab.addEventListener('shown.bs.tab', () => {
-                     const codeMirrorElement = document.querySelector(".CodeMirror");
-                     if (codeMirrorElement){
-                         codeMirrorElement.CodeMirror.refresh();
+                     const codeMirrorElements = document.querySelectorAll(".CodeMirror");
+                     if (codeMirrorElements){
+                         codeMirrorElements.forEach(function (c){
+                             c.CodeMirror.refresh();
+                         })
                      }
                      else{
                         setupCodeMirror();

--- a/src/Web/Areas/DataDictionary/Views/Field/Index.cshtml
+++ b/src/Web/Areas/DataDictionary/Views/Field/Index.cshtml
@@ -82,7 +82,8 @@
                 hintKey: '{'
             });
          }
-            
+         
+           
          function listenTabs (){
             setupCodeMirror(); 
             
@@ -108,7 +109,7 @@
          
          document.addEventListener("DOMContentLoaded",listenTabs)
     </script>
-    
+
     <script type="text/javascript">        
         document.addEventListener("DOMContentLoaded",function (){
             sortableGrid();
@@ -232,74 +233,74 @@
         }
     </script>
 
-}
+    }
 
-<partial name="_Menu" model="@(new DataDictionaryViewModel(ViewBag.ElementName, ViewBag.MenuId))"/>
+    <partial name="_Menu" model="@(new DataDictionaryViewModel(ViewBag.ElementName, ViewBag.MenuId))"/>
 
-@using (Html.BeginForm("Index", "Field", FormMethod.Post))
-{
-    <input type="hidden" name="selected-tab" id="selected-tab" value="@ViewBag.Tab" />
-    <div class="row">
-        <div class="col-sm-3">
-            <text-group configure="ConfigureFieldSearchBox"/>
-            <br/>
-            <div class="jjrelative">
-                <div id="listField">
-                    <div class="list-group jjsortable" id="sortable-grid">
-                        @if (ViewBag.Fields.Count == 0)
-                        {
-                            <div>@StringLocalizer["No record found"]</div>
-                        }
-                        @for(int i = 0; i < ViewBag.Fields.Count; i++)
-                        {
-                            FormElementField field = ViewBag.Fields[i];
-                            var fieldName = field.Name;
-                            
-                            <a href="javascript:loadFieldDetails('@Url.Action("Detail", new { elementName = ViewBag.ElementName, fieldName })', '@fieldName' );"
-                               class="list-group-item @(fieldName.Equals(Model.Name) ? "active" : "")"
-                               id="@fieldName">
-                                <div style="height: 33px;">
-                                    <div class="@BootstrapHelper.PullLeft">
-                                        <b>@fieldName</b>
-                                        @if (field.IsPk)
-                                        {
-                                            <span class="fa fa-star" style="color:#efd829;" data-bs-toggle="tooltip" data-bs-original-title="@StringLocalizer["Primary key"]"></span>
-                                        }
-                                        @if (field.Component is not FormComponent.Text)
-                                        {
-                                            <span class="@GetFontAwesomeIconClass(field.Component).GetCssClass() ms-1" data-bs-toggle="tooltip" data-bs-original-title="@field.Component.ToString()"></span>
-                                        }
-                                        <br>
-                                        @if (field.Label != null)
-                                        {
-                                            var label = field.Label.Replace("<br>", " ").Replace("<BR>", " ").Replace("<br />", " ");
-                                            if (label.Length > 35)
+    @using (Html.BeginForm("Index", "Field", FormMethod.Post))
+    {
+        <input type="hidden" name="selected-tab" id="selected-tab" value="@ViewBag.Tab"/>
+        <div class="row">
+            <div class="col-sm-3">
+                <text-group configure="ConfigureFieldSearchBox"/>
+                <br/>
+                <div class="jjrelative">
+                    <div id="listField">
+                        <div class="list-group jjsortable" id="sortable-grid">
+                            @if (ViewBag.Fields.Count == 0)
+                            {
+                                <div>@StringLocalizer["No record found"]</div>
+                            }
+                            @for (int i = 0; i < ViewBag.Fields.Count; i++)
+                            {
+                                FormElementField field = ViewBag.Fields[i];
+                                var fieldName = field.Name;
+
+                                <a href="javascript:loadFieldDetails('@Url.Action("Detail", new { elementName = ViewBag.ElementName, fieldName })', '@fieldName' );"
+                                   class="list-group-item @(fieldName.Equals(Model.Name) ? "active" : "")"
+                                   id="@fieldName">
+                                    <div style="height: 33px;">
+                                        <div class="@BootstrapHelper.PullLeft">
+                                            <b>@fieldName</b>
+                                            @if (field.IsPk)
                                             {
-                                                label = $"{label[..30]}...";
+                                                <span class="fa fa-star" style="color:#efd829;" data-bs-toggle="tooltip" data-bs-original-title="@StringLocalizer["Primary key"]"></span>
                                             }
-                                            <span>@label</span>
-                                            <span> - </span>
-                                        }
-                                        <small>@SqlServerProvider.GetFieldDataTypeScript(field)</small>
+                                            @if (field.Component is not FormComponent.Text)
+                                            {
+                                                <span class="@GetFontAwesomeIconClass(field.Component).GetCssClass() ms-1" data-bs-toggle="tooltip" data-bs-original-title="@field.Component.ToString()"></span>
+                                            }
+                                            <br>
+                                            @if (field.Label != null)
+                                            {
+                                                var label = field.Label.Replace("<br>", " ").Replace("<BR>", " ").Replace("<br />", " ");
+                                                if (label.Length > 35)
+                                                {
+                                                    label = $"{label[..30]}...";
+                                                }
+                                                <span>@label</span>
+                                                <span> - </span>
+                                            }
+                                            <small>@SqlServerProvider.GetFieldDataTypeScript(field)</small>
+                                        </div>
+                                        <div class="@BootstrapHelper.PullRight jjsortable-icon" title="@StringLocalizer["Drag and drop to move"]">
+                                        </div>
+                                        <span class="@BootstrapHelper.PullRight jjsortable-span" title="@StringLocalizer["Drag and drop to move"]">
+                                            @i
+                                        </span>
                                     </div>
-                                    <div class="@BootstrapHelper.PullRight jjsortable-icon" title="@StringLocalizer["Drag and drop to move"]">
-                                    </div>
-                                    <span class="@BootstrapHelper.PullRight jjsortable-span" title="@StringLocalizer["Drag and drop to move"]">
-                                        @i
-                                    </span>
-                                </div>
-                            </a>
-                        }
+                                </a>
+                            }
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
-        <div class="col-sm-9" style="padding-left:0px">
-            <div class="jjrelative" id="field-details">
-                <partial name="_Detail" model="Model"/>
+            <div class="col-sm-9" style="padding-left:0px">
+                <div class="jjrelative" id="field-details">
+                    <partial name="_Detail" model="Model"/>
+                </div>
             </div>
+            <br/>
         </div>
-        <br />
-    </div>
-}
+    }
 

--- a/src/Web/Areas/DataDictionary/Views/Field/_Detail.cshtml
+++ b/src/Web/Areas/DataDictionary/Views/Field/_Detail.cshtml
@@ -74,7 +74,7 @@
                     @Html.TextBoxFor(model => model.Label, new { @class = "form-control" })
                 </div>
                 <div class="@BootstrapHelper.FormGroup col-sm-6">
-                    <expression for="DefaultValue" tooltip="Expression for a default value. Check expressions at the docs for more information." is-boolean="false"/>
+                    <expression for="DefaultValue"  tooltip="Expression for a default value. Check expressions at the docs for more information." is-boolean="false"/>
                 </div>
                 <div class="@BootstrapHelper.FormGroup col-sm-2 required">
                     <label class="@BootstrapHelper.Label " asp-for="Filter.Type">@StringLocalizer["Filter"]</label>
@@ -195,13 +195,13 @@
         <div id="div-advanced" class="tab-pane fade @Active("#div-advanced")">
             <div class="row">
                 <div class="@BootstrapHelper.FormGroup col-sm-12 required">
-                    <expression for="VisibleExpression" tooltip="Boolean expression to show the field. Check expressions at the docs for more information."/>
+                    <expression for="VisibleExpression" icon="IconType.Eye" tooltip="Boolean expression to show the field. Check expressions at the docs for more information."/>
                 </div>
                 <div class="@BootstrapHelper.FormGroup col-sm-12 required">
-                     <expression for="EnableExpression" tooltip="Boolean expression to enable the field. Check expressions at the docs for more information."/>
+                     <expression for="EnableExpression" icon="IconType.Pencil" tooltip="Boolean expression to enable the field. Check expressions at the docs for more information."/>
                 </div>
                 <div class="@BootstrapHelper.FormGroup col-sm-12">
-                    <expression for="TriggerExpression" tooltip="Expression triggered whenever a field triggers a POST to the server. Check expressions at the docs for more information." is-boolean="false"/>
+                    <expression for="TriggerExpression" icon="IconType.Bolt" tooltip="Expression triggered whenever a field triggers a POST to the server. Check expressions at the docs for more information." is-boolean="false"/>
                 </div>
                 <div class="@BootstrapHelper.FormGroup col-sm-4">
                     <label class="@BootstrapHelper.Label " asp-for="CssClass">@StringLocalizer["Css Class"]</label>

--- a/src/Web/Areas/DataDictionary/Views/Field/_Detail.cshtml
+++ b/src/Web/Areas/DataDictionary/Views/Field/_Detail.cshtml
@@ -63,95 +63,106 @@
             <a class="nav-link" @BootstrapHelper.GetDataToggle("tab") data-bs-target="#div-advanced" href="#div-advanced">@StringLocalizer["Advanced"]</a>
         </li>
     </ul>
-    
+
     <div class="tab-content" style="margin-top: 20px;">
         <div id="div-general" class="tab-pane fade @Active("#div-general")">
-            <div class="row">
-                <div class="@BootstrapHelper.FormGroup col-sm-4 required">
-                    <label class="@BootstrapHelper.Label " asp-for="Name">@StringLocalizer["Field Name"]</label>
-                    <tooltip title="Name of the field at your data source."/>
-                    @Html.TextBoxFor(model => Model.Name, new { maxlength = "64", @class = "form-control" })
-                    <input type="hidden" id="originalName" name="originalName" value="@ViewBag.OriginalName"/>
-                </div>
-                <div class="@BootstrapHelper.FormGroup col-sm-4">
-                    <label class="@BootstrapHelper.Label " asp-for="Label">@StringLocalizer["Label"]</label>
-                    <tooltip title="Name of the field displayed at the form."/>
-                    @Html.TextBoxFor(model => model.Label, new { @class = "form-control" })
-                </div>
-                <div class="@BootstrapHelper.FormGroup col-sm-2 required">
-                    <label class="@BootstrapHelper.Label " asp-for="Filter.Type">@StringLocalizer["Filter"]</label>
-                    <select asp-for="Filter.Type" class="form-control form-select" asp-items="Html.GetEnumSelectList<FilterMode>()"></select>
-                </div>
-                <div class="@BootstrapHelper.FormGroup col-sm-2 required">
-                    <label class="@BootstrapHelper.Label " asp-for="DataBehavior">@StringLocalizer["Data Behavior"]</label>
+                <div class="row">
 
-                    <tooltip title="Field behavior in relation to the database"/>
-
-                    <select asp-for="DataBehavior" class="form-control form-select" asp-items="Html.GetEnumSelectList<FieldBehavior>()"></select>
-                </div>
-                <div class="@BootstrapHelper.FormGroup col-sm-1 required">
-                    <label class="@BootstrapHelper.Label " asp-for="DataType">@StringLocalizer["Data Type"]</label>
-                    <select asp-for="DataType" class="form-control form-select" asp-items="Html.GetEnumSelectList<FieldType>().OrderBy(f => f.Text)"></select>
-                </div>
-                <div class="@BootstrapHelper.FormGroup col-sm-1">
-                    <label class="@BootstrapHelper.Label " asp-for="Size">@StringLocalizer["Size"]</label>
-                    <tooltip title="Field size. At SQL Server use -1 to use the MAX keyword."/>
-                    @Html.TextBoxFor(model => model.Size, new { @class = "form-control" })
-                </div>
-                <div class="@BootstrapHelper.FormGroup col-sm-1 required">
-                    <label class="@BootstrapHelper.Label " asp-for="IsRequired">@StringLocalizer["Required"]</label>
-                    <checkbox for="IsRequired" switch="true" switch-size="CheckBoxSwitchSize.Medium"/>
-                </div>
-                <div class="@BootstrapHelper.FormGroup col-sm-1 required">
-                    <label class="@BootstrapHelper.Label " asp-for="IsPk">@StringLocalizer["PK"]</label>
-                    <checkbox for="IsPk" switch="true" switch-size="CheckBoxSwitchSize.Medium"/>
-                </div>
-                <div class="@BootstrapHelper.FormGroup col-sm-1 required">
-                    <label class="@BootstrapHelper.Label " asp-for="AutoNum">@StringLocalizer["Identity"]</label>
-                    <checkbox for="AutoNum" switch="true" switch-size="CheckBoxSwitchSize.Medium"/>
-                </div>
-                <div class="@BootstrapHelper.FormGroup col-sm-3">
-                    <label class="@BootstrapHelper.Label " asp-for="CssClass">@StringLocalizer["Css Class"]</label>
-                    <tooltip title="Class name (CSS) one to be assigned to object group rendering"/>
-
-                    @Html.TextBoxFor(model => model.CssClass, new { @class = "form-control" })
-                </div>
-
-                <div class="@BootstrapHelper.FormGroup col-sm-1">
-                    <label class="@BootstrapHelper.Label " asp-for="LineGroup">@StringLocalizer["Row Number"]</label>
-                    <tooltip title="Row number at the form, used to break the line in the form flex layout."/>
-
-                    @Html.TextBoxFor(model => model.LineGroup, new { type = "number", @class = "form-control" })
-                </div>
-                <div class="@BootstrapHelper.FormGroup col-sm-3 required">
-                    <label class="@BootstrapHelper.Label " asp-for="Export">@StringLocalizer["Export"]</label>
-                    <tooltip title="Allows you to export the field"/>
-                    <checkbox for="Export" switch="true"/>
-                </div>
-                
-                @if (Options.Value.SupportNetFramework)
-                {
-                    <div class="@BootstrapHelper.FormGroup col-sm-2 required">
-                        <label class="@BootstrapHelper.Label " asp-for="ValidateRequest">@StringLocalizer["Validate Request"]</label>
-                        <tooltip title="Validates possibly dangerous values on request on .NET Framework 4.8"/>
-                        <checkbox for="ValidateRequest" switch="true"/>
+                    <div class="@BootstrapHelper.FormGroup col-sm-5 required">
+                        <label class="@BootstrapHelper.Label " asp-for="Name">@StringLocalizer["Field Name"]</label>
+                        <tooltip title="Name of the field at your data source."/>
+                        @Html.TextBoxFor(model => Model.Name, new { maxlength = "64", @class = "form-control" })
+                        <input type="hidden" id="originalName" name="originalName" value="@ViewBag.OriginalName"/>
                     </div>
-                }
-                
-                <div class="@BootstrapHelper.FormGroup col-sm-12">
-                    <label class="@BootstrapHelper.Label " asp-for="HelpDescription">
-                        @StringLocalizer["Help Description"]
-                    </label>
-                    <tooltip title="The help text will be displayed like this on the form."/>
-                    @Html.TextBoxFor(model => model.HelpDescription, new { @class = "form-control" })
+                    <div class="@BootstrapHelper.FormGroup col-sm-7">
+                        <label class="@BootstrapHelper.Label " asp-for="Label">@StringLocalizer["Label"]</label>
+                        <tooltip title="Name of the field displayed at the form."/>
+                        @Html.TextBoxFor(model => model.Label, new { @class = "form-control" })
+                    </div>
                 </div>
+
+                <div class="row">
+                    <div class="@BootstrapHelper.FormGroup col-sm-3 required">
+                        <label class="@BootstrapHelper.Label " asp-for="Filter.Type">@StringLocalizer["Filter"]</label>
+                        <select asp-for="Filter.Type" class="form-control form-select" asp-items="Html.GetEnumSelectList<FilterMode>()"></select>
+                    </div>
+                    <div class="@BootstrapHelper.FormGroup col-sm-2 required">
+                        <label class="@BootstrapHelper.Label " asp-for="DataBehavior">@StringLocalizer["Data Behavior"]</label>
+
+                        <tooltip title="Field behavior in relation to the database"/>
+
+                        <select asp-for="DataBehavior" class="form-control form-select" asp-items="Html.GetEnumSelectList<FieldBehavior>()"></select>
+                    </div>
+                    <div class="@BootstrapHelper.FormGroup col-sm-2 required">
+                        <label class="@BootstrapHelper.Label " asp-for="DataType">@StringLocalizer["Data Type"]</label>
+                        <select asp-for="DataType" class="form-control form-select" asp-items="Html.GetEnumSelectList<FieldType>().OrderBy(f => f.Text)"></select>
+                    </div>
+                    <div class="@BootstrapHelper.FormGroup col-sm-2">
+                        <label class="@BootstrapHelper.Label " asp-for="Size">@StringLocalizer["Size"]</label>
+                        <tooltip title="Field size. At SQL Server use -1 to use the MAX keyword."/>
+                        @Html.TextBoxFor(model => model.Size, new { @class = "form-control" })
+                    </div>
+                    <div class="col-sm-3">
+                        <div class="row">
+                            <div class="@BootstrapHelper.FormGroup col-sm-4 required">
+                                                    <label class="@BootstrapHelper.Label " asp-for="IsRequired">@StringLocalizer["Required"]</label>
+                                                    <checkbox for="IsRequired" switch="true" switch-size="CheckBoxSwitchSize.Medium"/>
+                                                </div>
+                                                <div class="@BootstrapHelper.FormGroup col-sm-4 required">
+                                                    <label class="@BootstrapHelper.Label " asp-for="IsPk">@StringLocalizer["PK"]</label>
+                                                    <checkbox for="IsPk" switch="true" switch-size="CheckBoxSwitchSize.Medium"/>
+                                                </div>
+                                                <div class="@BootstrapHelper.FormGroup col-sm-4 required">
+                                                    <label class="@BootstrapHelper.Label " asp-for="AutoNum">@StringLocalizer["Identity"]</label>
+                                                    <checkbox for="AutoNum" switch="true" switch-size="CheckBoxSwitchSize.Medium"/>
+                                                </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="@BootstrapHelper.FormGroup col-sm-12">
+                        <label class="@BootstrapHelper.Label " asp-for="HelpDescription">
+                            @StringLocalizer["Help Description"]
+                        </label>
+                        <tooltip title="The help text will be displayed like this on the form."/>
+                        @Html.TextBoxFor(model => model.HelpDescription, new { @class = "form-control" })
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="@BootstrapHelper.FormGroup col-sm-3">
+                        <label class="@BootstrapHelper.Label " asp-for="CssClass">@StringLocalizer["Css Class"]</label>
+                        <tooltip title="Class name (CSS) one to be assigned to object group rendering"/>
+
+                        @Html.TextBoxFor(model => model.CssClass, new { @class = "form-control" })
+                    </div>
+
+                    <div class="@BootstrapHelper.FormGroup col-sm-2">
+                        <label class="@BootstrapHelper.Label " asp-for="LineGroup">@StringLocalizer["Row Number"]</label>
+                        <tooltip title="Row number at the form, used to break the line in the form flex layout."/>
+
+                        @Html.TextBoxFor(model => model.LineGroup, new { type = "number", @class = "form-control" })
+                    </div>
+                    <div class="@BootstrapHelper.FormGroup col-sm-3 required">
+                        <label class="@BootstrapHelper.Label " asp-for="Export">@StringLocalizer["Export"]</label>
+                        <tooltip title="Allows you to export the field"/>
+                        <checkbox for="Export" switch="true"/>
+                    </div>
+
+                    @if (Options.Value.SupportNetFramework)
+                    {
+                        <div class="@BootstrapHelper.FormGroup col-sm-2 required">
+                            <label class="@BootstrapHelper.Label " asp-for="ValidateRequest">@StringLocalizer["Validate Request"]</label>
+                            <tooltip title="Validates possibly dangerous values on request on .NET Framework 4.8"/>
+                            <checkbox for="ValidateRequest" switch="true"/>
+                        </div>
+                    }
+                </div>
+
             </div>
-
-        </div>
-
         <div id="div-component" class="tab-pane fade @Active("#div-component")">
             <div class="row">
-
                 <div class="@BootstrapHelper.FormGroup col-sm-4 required">
                     <label class="@BootstrapHelper.Label " asp-for="Component">@StringLocalizer["Component"]</label>
                     <select asp-for="Component" class="form-control form-select" onchange="this.form.submit();" asp-items="Html.GetEnumSelectList<FormComponent>()"></select>
@@ -221,7 +232,6 @@
             }
 
         </div>
-
         <div id="div-advanced" class="tab-pane fade @Active("#div-advanced")">
             <div class="row">
                 <div class="@BootstrapHelper.FormGroup col-sm-12">
@@ -236,11 +246,9 @@
                 <div class="@BootstrapHelper.FormGroup col-sm-12">
                     <expression for="TriggerExpression" icon="IconType.Bolt" tooltip="Expression triggered whenever a field triggers a POST to the server. Check expressions at the docs for more information." is-boolean="false"/>
                 </div>
-
             </div>
         </div>
     </div>
-    
     <div class="row">
         <div class="col-sm-12 jjtoolbar">
             @{
@@ -257,8 +265,9 @@
             }
         </div>
     </div>
-
 </div>
+
+
 
 @functions{
 

--- a/src/Web/Areas/DataDictionary/Views/Field/_Detail.cshtml
+++ b/src/Web/Areas/DataDictionary/Views/Field/_Detail.cshtml
@@ -62,21 +62,19 @@
     <div class="tab-content" style="margin-top: 20px;">
         <div id="div-general" class="tab-pane fade @Active("#div-general")">
             <div class="row">
-                <div class="@BootstrapHelper.FormGroup col-sm-4 required">
+                <div class="@BootstrapHelper.FormGroup col-sm-3 required">
                     <label class="@BootstrapHelper.Label " asp-for="Name">@StringLocalizer["Field Name"]</label>
                     <tooltip title="Name of the field at your data source."/>
                     @Html.TextBoxFor(model => Model.Name, new { maxlength = "64", @class = "form-control" })
                     <input type="hidden" id="originalName" name="originalName" value="@ViewBag.OriginalName"/>
                 </div>
-                <div class="@BootstrapHelper.FormGroup col-sm-4">
+                <div class="@BootstrapHelper.FormGroup col-sm-3">
                     <label class="@BootstrapHelper.Label " asp-for="Label">@StringLocalizer["Label"]</label>
                     <tooltip title="Name of the field displayed at the form."/>
                     @Html.TextBoxFor(model => model.Label, new { @class = "form-control" })
                 </div>
-                <div class="@BootstrapHelper.FormGroup col-sm-4">
-                    <label class="@BootstrapHelper.Label " asp-for="DefaultValue">@StringLocalizer["Default Value Expression"]</label>
-                    <tooltip title="Expression for a default value. Check expressions at the docs for more information."/>
-                    @Html.TextBoxFor(model => model.DefaultValue, new { @class = "form-control" })
+                <div class="@BootstrapHelper.FormGroup col-sm-6">
+                    <expression for="DefaultValue" tooltip="Expression for a default value. Check expressions at the docs for more information."/>
                 </div>
                 <div class="@BootstrapHelper.FormGroup col-sm-2 required">
                     <label class="@BootstrapHelper.Label " asp-for="Filter.Type">@StringLocalizer["Filter"]</label>
@@ -197,22 +195,13 @@
         <div id="div-advanced" class="tab-pane fade @Active("#div-advanced")">
             <div class="row">
                 <div class="@BootstrapHelper.FormGroup col-sm-12 required">
-                    <label class="@BootstrapHelper.Label " asp-for="VisibleExpression">@StringLocalizer["Visible Expression"]</label>
-                    <tooltip title="Boolean expression to show the field. Check expressions at the docs for more information."/>
-
-                    @Html.TextBoxFor(model => model.VisibleExpression, new { @class = "form-control" })
+                    <expression for="VisibleExpression" tooltip="Boolean expression to show the field. Check expressions at the docs for more information."/>
                 </div>
                 <div class="@BootstrapHelper.FormGroup col-sm-12 required">
-                    <label class="@BootstrapHelper.Label " asp-for="EnableExpression">@StringLocalizer["Enable Expression"]</label>
-                    <tooltip title="Boolean expression to enable the field. Check expressions at the docs for more information."/>
-
-                    @Html.TextBoxFor(model => model.EnableExpression, new { @class = "form-control" })
+                     <expression for="EnableExpression" tooltip="Boolean expression to enable the field. Check expressions at the docs for more information."/>
                 </div>
                 <div class="@BootstrapHelper.FormGroup col-sm-12">
-                    <label class="@BootstrapHelper.Label " asp-for="TriggerExpression">@StringLocalizer["Trigger Expression"]</label>
-                    <tooltip title="Expression triggered whenever a field triggers a POST to the server. Check expressions at the docs for more information."/>
-
-                    @Html.TextBoxFor(model => model.TriggerExpression, new { @class = "form-control" })
+                    <expression for="TriggerExpression" tooltip="Expression triggered whenever a field triggers a POST to the server. Check expressions at the docs for more information."/>
                 </div>
                 <div class="@BootstrapHelper.FormGroup col-sm-4">
                     <label class="@BootstrapHelper.Label " asp-for="CssClass">@StringLocalizer["Css Class"]</label>

--- a/src/Web/Areas/DataDictionary/Views/Field/_Detail.cshtml
+++ b/src/Web/Areas/DataDictionary/Views/Field/_Detail.cshtml
@@ -4,8 +4,11 @@
 @using JJMasterData.Core.UI
 @using JJMasterData.Core.UI.Components
 @using JJMasterData.Web.Areas.DataDictionary.Models.ViewModels
+@using JJMasterData.Web.Configuration.Options
+
 @model JJMasterData.Core.DataDictionary.Models.FormElementField
 @inject IStringLocalizer<JJMasterDataResources> StringLocalizer
+@inject IOptions<JJMasterDataWebOptions> Options
 
 @{
     string currentTab = ViewBag.Tab ?? "#div-general";
@@ -40,13 +43,15 @@
             window.parent.document.querySelector('#current_field').value = fieldName;
         });
     }
-
-   
 </script>
 
 @Html.HiddenFor(model => Model.PanelId)
 <div class="container-fluid jjcontainer">
-
+    <div class="row">
+        <div class="col-sm-12">
+            @Html.Raw(ViewBag.Error)
+        </div>
+    </div>
     <ul id="field-nav" class="nav nav-tabs">
         <li class="nav-item" id="nav-general" @Active("#div-general")>
             <a class="nav-link" @BootstrapHelper.GetDataToggle("tab") data-bs-target="#div-general" href="#div-general">@StringLocalizer["General"]</a>
@@ -58,23 +63,20 @@
             <a class="nav-link" @BootstrapHelper.GetDataToggle("tab") data-bs-target="#div-advanced" href="#div-advanced">@StringLocalizer["Advanced"]</a>
         </li>
     </ul>
-
+    
     <div class="tab-content" style="margin-top: 20px;">
         <div id="div-general" class="tab-pane fade @Active("#div-general")">
             <div class="row">
-                <div class="@BootstrapHelper.FormGroup col-sm-3 required">
+                <div class="@BootstrapHelper.FormGroup col-sm-4 required">
                     <label class="@BootstrapHelper.Label " asp-for="Name">@StringLocalizer["Field Name"]</label>
                     <tooltip title="Name of the field at your data source."/>
                     @Html.TextBoxFor(model => Model.Name, new { maxlength = "64", @class = "form-control" })
                     <input type="hidden" id="originalName" name="originalName" value="@ViewBag.OriginalName"/>
                 </div>
-                <div class="@BootstrapHelper.FormGroup col-sm-3">
+                <div class="@BootstrapHelper.FormGroup col-sm-4">
                     <label class="@BootstrapHelper.Label " asp-for="Label">@StringLocalizer["Label"]</label>
                     <tooltip title="Name of the field displayed at the form."/>
                     @Html.TextBoxFor(model => model.Label, new { @class = "form-control" })
-                </div>
-                <div class="@BootstrapHelper.FormGroup col-sm-6">
-                    <expression for="DefaultValue"  tooltip="Expression for a default value. Check expressions at the docs for more information." is-boolean="false"/>
                 </div>
                 <div class="@BootstrapHelper.FormGroup col-sm-2 required">
                     <label class="@BootstrapHelper.Label " asp-for="Filter.Type">@StringLocalizer["Filter"]</label>
@@ -87,11 +89,11 @@
 
                     <select asp-for="DataBehavior" class="form-control form-select" asp-items="Html.GetEnumSelectList<FieldBehavior>()"></select>
                 </div>
-                <div class="@BootstrapHelper.FormGroup col-sm-2 required">
+                <div class="@BootstrapHelper.FormGroup col-sm-1 required">
                     <label class="@BootstrapHelper.Label " asp-for="DataType">@StringLocalizer["Data Type"]</label>
                     <select asp-for="DataType" class="form-control form-select" asp-items="Html.GetEnumSelectList<FieldType>().OrderBy(f => f.Text)"></select>
                 </div>
-                <div class="@BootstrapHelper.FormGroup col-sm-2">
+                <div class="@BootstrapHelper.FormGroup col-sm-1">
                     <label class="@BootstrapHelper.Label " asp-for="Size">@StringLocalizer["Size"]</label>
                     <tooltip title="Field size. At SQL Server use -1 to use the MAX keyword."/>
                     @Html.TextBoxFor(model => model.Size, new { @class = "form-control" })
@@ -108,6 +110,34 @@
                     <label class="@BootstrapHelper.Label " asp-for="AutoNum">@StringLocalizer["Identity"]</label>
                     <checkbox for="AutoNum" switch="true" switch-size="CheckBoxSwitchSize.Medium"/>
                 </div>
+                <div class="@BootstrapHelper.FormGroup col-sm-3">
+                    <label class="@BootstrapHelper.Label " asp-for="CssClass">@StringLocalizer["Css Class"]</label>
+                    <tooltip title="Class name (CSS) one to be assigned to object group rendering"/>
+
+                    @Html.TextBoxFor(model => model.CssClass, new { @class = "form-control" })
+                </div>
+
+                <div class="@BootstrapHelper.FormGroup col-sm-1">
+                    <label class="@BootstrapHelper.Label " asp-for="LineGroup">@StringLocalizer["Row Number"]</label>
+                    <tooltip title="Row number at the form, used to break the line in the form flex layout."/>
+
+                    @Html.TextBoxFor(model => model.LineGroup, new { type = "number", @class = "form-control" })
+                </div>
+                <div class="@BootstrapHelper.FormGroup col-sm-3 required">
+                    <label class="@BootstrapHelper.Label " asp-for="Export">@StringLocalizer["Export"]</label>
+                    <tooltip title="Allows you to export the field"/>
+                    <checkbox for="Export" switch="true"/>
+                </div>
+                
+                @if (Options.Value.SupportNetFramework)
+                {
+                    <div class="@BootstrapHelper.FormGroup col-sm-2 required">
+                        <label class="@BootstrapHelper.Label " asp-for="ValidateRequest">@StringLocalizer["Validate Request"]</label>
+                        <tooltip title="Validates possibly dangerous values on request on .NET Framework 4.8"/>
+                        <checkbox for="ValidateRequest" switch="true"/>
+                    </div>
+                }
+                
                 <div class="@BootstrapHelper.FormGroup col-sm-12">
                     <label class="@BootstrapHelper.Label " asp-for="HelpDescription">
                         @StringLocalizer["Help Description"]
@@ -147,12 +177,12 @@
             </div>
 
             @if (Model.Component is FormComponent.Text 
-                    or FormComponent.Email 
-                    or FormComponent.Number 
-                    or FormComponent.Cep 
-                    or FormComponent.Cnpj 
-                    or FormComponent.Cpf 
-                    or FormComponent.CnpjCpf)
+                or FormComponent.Email 
+                or FormComponent.Number 
+                or FormComponent.Cep 
+                or FormComponent.Cnpj 
+                or FormComponent.Cpf 
+                or FormComponent.CnpjCpf)
             {
                 if (ViewBag.OriginalName == null || ViewBag.OriginalName == "")
                 {
@@ -194,57 +224,23 @@
 
         <div id="div-advanced" class="tab-pane fade @Active("#div-advanced")">
             <div class="row">
+                <div class="@BootstrapHelper.FormGroup col-sm-12">
+                    <expression for="DefaultValue" icon="IconType.Check" tooltip="Expression for a default value. Check expressions at the docs for more information." is-boolean="false"/>
+                </div>
                 <div class="@BootstrapHelper.FormGroup col-sm-12 required">
                     <expression for="VisibleExpression" icon="IconType.Eye" tooltip="Boolean expression to show the field. Check expressions at the docs for more information."/>
                 </div>
                 <div class="@BootstrapHelper.FormGroup col-sm-12 required">
-                     <expression for="EnableExpression" icon="IconType.Pencil" tooltip="Boolean expression to enable the field. Check expressions at the docs for more information."/>
+                    <expression for="EnableExpression" icon="IconType.Pencil" tooltip="Boolean expression to enable the field. Check expressions at the docs for more information."/>
                 </div>
                 <div class="@BootstrapHelper.FormGroup col-sm-12">
                     <expression for="TriggerExpression" icon="IconType.Bolt" tooltip="Expression triggered whenever a field triggers a POST to the server. Check expressions at the docs for more information." is-boolean="false"/>
                 </div>
-                <div class="@BootstrapHelper.FormGroup col-sm-4">
-                    <label class="@BootstrapHelper.Label " asp-for="CssClass">@StringLocalizer["Css Class"]</label>
-                    <tooltip title="Class name (CSS) one to be assigned to object group rendering"/>
 
-                    @Html.TextBoxFor(model => model.CssClass, new { @class = "form-control" })
-                </div>
-                <div class="@BootstrapHelper.FormGroup col-sm-2">
-                    <label class="@BootstrapHelper.Label " asp-for="LineGroup">@StringLocalizer["Group Line"]</label>
-                    <tooltip title="Row counter, used to break the line in the form (row class)"/>
-
-                    @Html.TextBoxFor(model => model.LineGroup, new { type = "number", @class = "form-control" })
-                </div>
-                <div class="@BootstrapHelper.FormGroup col-sm-2 required">
-                    <label class="@BootstrapHelper.Label " asp-for="Export">@StringLocalizer["Export"]</label>
-                    <tooltip title="Allows you to export the field"/>
-                    <checkbox for="Export" switch="true"/>
-                </div>
-                
-                <div class="@BootstrapHelper.FormGroup col-sm-4 required">
-                    <label class="@BootstrapHelper.Label " asp-for="ValidateRequest">@StringLocalizer["Validate Request"]</label>
-                    <tooltip title="Validates possibly dangerous values on request on .NET Framework 4.8"/>
-                    <checkbox for="ValidateRequest" switch="true"/>
-                </div>
             </div>
         </div>
     </div>
-
-    <div class="row">
-        <div class="col-sm-12">
-            @Html.Raw(ViewBag.Error)
-        </div>
-
-        <div class="col-sm-12">
-            <div id="div-success" class="alert alert-success alert-dismissible" role="alert" style="display:none">
-                <button type="button" class="@BootstrapHelper.Close" @BootstrapHelper.GetDataDismiss("alert") aria-label="Close">
-                    <span aria-hidden="true">@BootstrapHelper.CloseButtonTimes</span>
-                </button>
-                <strong>@StringLocalizer["Success!"]</strong> @StringLocalizer["Record saved successfully."]
-            </div>
-        </div>
-    </div>
-
+    
     <div class="row">
         <div class="col-sm-12 jjtoolbar">
             @{

--- a/src/Web/Areas/DataDictionary/Views/Field/_Detail.cshtml
+++ b/src/Web/Areas/DataDictionary/Views/Field/_Detail.cshtml
@@ -74,7 +74,7 @@
                     @Html.TextBoxFor(model => model.Label, new { @class = "form-control" })
                 </div>
                 <div class="@BootstrapHelper.FormGroup col-sm-6">
-                    <expression for="DefaultValue" tooltip="Expression for a default value. Check expressions at the docs for more information."/>
+                    <expression for="DefaultValue" tooltip="Expression for a default value. Check expressions at the docs for more information." is-boolean="false"/>
                 </div>
                 <div class="@BootstrapHelper.FormGroup col-sm-2 required">
                     <label class="@BootstrapHelper.Label " asp-for="Filter.Type">@StringLocalizer["Filter"]</label>
@@ -201,7 +201,7 @@
                      <expression for="EnableExpression" tooltip="Boolean expression to enable the field. Check expressions at the docs for more information."/>
                 </div>
                 <div class="@BootstrapHelper.FormGroup col-sm-12">
-                    <expression for="TriggerExpression" tooltip="Expression triggered whenever a field triggers a POST to the server. Check expressions at the docs for more information."/>
+                    <expression for="TriggerExpression" tooltip="Expression triggered whenever a field triggers a POST to the server. Check expressions at the docs for more information." is-boolean="false"/>
                 </div>
                 <div class="@BootstrapHelper.FormGroup col-sm-4">
                     <label class="@BootstrapHelper.Label " asp-for="CssClass">@StringLocalizer["Css Class"]</label>

--- a/src/Web/Binders/ExpressionModelBinder.cs
+++ b/src/Web/Binders/ExpressionModelBinder.cs
@@ -24,7 +24,7 @@ public class ExpressionModelBinder : IModelBinder
         }
         else
         {
-            bindingContext.Result = ModelBindingResult.Success(null);
+            bindingContext.Result = ModelBindingResult.Failed();
         }
 
         return Task.CompletedTask;

--- a/src/Web/Binders/ExpressionModelBinder.cs
+++ b/src/Web/Binders/ExpressionModelBinder.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace JJMasterData.Web.Binders;
+
+public class ExpressionModelBinder : IModelBinder
+{
+    public Task BindModelAsync(ModelBindingContext bindingContext)
+    {
+        if (bindingContext == null)
+        {
+            throw new ArgumentNullException(nameof(bindingContext));
+        }
+        
+        var propertyName = bindingContext.ModelName;
+
+        var expressionType = bindingContext.ValueProvider.GetValue($"{propertyName}-ExpressionType").FirstValue;
+        var expressionValue = bindingContext.ValueProvider.GetValue($"{propertyName}-ExpressionValue").FirstValue;
+
+        if (!string.IsNullOrWhiteSpace(expressionValue))
+        {
+            var result = $"{expressionType}:{expressionValue}";
+        
+            bindingContext.Result = ModelBindingResult.Success(result);
+        }
+        else
+        {
+            bindingContext.Result = ModelBindingResult.Success(null);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Web/Binders/ExpressionModelBinderProvider.cs
+++ b/src/Web/Binders/ExpressionModelBinderProvider.cs
@@ -1,0 +1,30 @@
+using JJMasterData.Core.DataDictionary.Models;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+
+namespace JJMasterData.Web.Binders;
+
+public class ExpressionModelBinderProvider : IModelBinderProvider
+{
+    public IModelBinder? GetBinder(ModelBinderProviderContext context)
+    {
+        if (context == null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+        
+        if (context.Metadata.PropertyName != null)
+        {
+            var propertyInfo = context.Metadata.ContainerType?.GetProperty(context.Metadata.PropertyName);
+            
+            var hasExpressionAttribute = propertyInfo?.GetCustomAttributes(typeof(ExpressionAttribute), false).Any() ?? false;
+
+            if (context.Metadata.ModelType == typeof(string) && hasExpressionAttribute)
+            {
+                return new BinderTypeModelBinder(typeof(ExpressionModelBinder));
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Web/Binders/ExpressionModelBinderProvider.cs
+++ b/src/Web/Binders/ExpressionModelBinderProvider.cs
@@ -15,7 +15,7 @@ public class ExpressionModelBinderProvider : IModelBinderProvider
         
         if (context.Metadata.PropertyName != null)
         {
-            var propertyInfo = context.Metadata.ContainerType?.GetProperty(context.Metadata.PropertyName);
+            var propertyInfo = context.Metadata.ContainerType?.GetProperties().FirstOrDefault(p=>p.Name == context.Metadata.PropertyName);
             
             var hasExpressionAttribute = propertyInfo?.GetCustomAttributes(typeof(ExpressionAttribute), false).Any() ?? false;
 

--- a/src/Web/Configuration/Options/JJMasterDataWebOptions.cs
+++ b/src/Web/Configuration/Options/JJMasterDataWebOptions.cs
@@ -24,4 +24,6 @@ public class JJMasterDataWebOptions : JJMasterDataCoreOptions
     public bool UseCustomBootstrap { get; set; }
     
     public string? CustomBootstrapPath { get; set; }
+    
+    public bool SupportNetFramework { get; set; }
 }

--- a/src/Web/Configuration/ServiceCollectionExtensions.cs
+++ b/src/Web/Configuration/ServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using JJMasterData.Core.Configuration;
 using JJMasterData.Core.Configuration.Options;
 using JJMasterData.Core.DataDictionary.Services;
 using JJMasterData.Web.Areas.DataDictionary.Services;
+using JJMasterData.Web.Binders;
 using JJMasterData.Web.Configuration.Options;
 using JJMasterData.Web.Extensions;
 using JJMasterData.Web.Models;
@@ -80,6 +81,11 @@ public static class ServiceCollectionExtensions
 
         services.AddMasterDataWebOptimizer();
 
+        services.AddControllersWithViews(options =>
+        {
+            options.ModelBinderProviders.Insert(0, new ExpressionModelBinderProvider());
+        }).AddViewLocalization();
+        
         services.AddHttpContextAccessor();
         services.AddSession();
         services.AddDistributedMemoryCache();

--- a/src/Web/Configuration/ServiceCollectionExtensions.cs
+++ b/src/Web/Configuration/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using JJMasterData.Commons.Configuration;
 using JJMasterData.Commons.Configuration.Options;
+using JJMasterData.Commons.Localization;
 using JJMasterData.Core.Configuration;
 using JJMasterData.Core.Configuration.Options;
 using JJMasterData.Core.DataDictionary.Services;
@@ -53,7 +54,7 @@ public static class ServiceCollectionExtensions
     public static JJMasterDataServiceBuilder AddJJMasterDataWeb(
         this IServiceCollection services,
         Action<JJMasterDataWebOptions> configureOptions
-        )
+    )
     {
         var webOptions = new JJMasterDataWebOptions();
         services.Configure(configureOptions);
@@ -82,10 +83,16 @@ public static class ServiceCollectionExtensions
         services.AddMasterDataWebOptimizer();
 
         services.AddControllersWithViews(options =>
-        {
-            options.ModelBinderProviders.Insert(0, new ExpressionModelBinderProvider());
-        }).AddViewLocalization();
-        
+            {
+                options.ModelBinderProviders.Insert(0, new ExpressionModelBinderProvider());
+            })
+            .AddViewLocalization()
+            .AddDataAnnotationsLocalization(options =>
+            {
+                options.DataAnnotationLocalizerProvider = (_, factory) =>
+                    factory.Create(typeof(JJMasterDataResources));
+            });
+
         services.AddHttpContextAccessor();
         services.AddSession();
         services.AddDistributedMemoryCache();
@@ -93,7 +100,8 @@ public static class ServiceCollectionExtensions
         services.AddActionFilters();
     }
 
-    internal static void AddMasterDataWebOptimizer(this IServiceCollection services, Action<IAssetPipeline>? configure = null)
+    internal static void AddMasterDataWebOptimizer(this IServiceCollection services,
+        Action<IAssetPipeline>? configure = null)
     {
         services.AddWebOptimizer(options =>
         {

--- a/src/Web/Scripts/CheckboxHelper.ts
+++ b/src/Web/Scripts/CheckboxHelper.ts
@@ -1,9 +1,9 @@
 class CheckboxHelper{
-    static check(name:string, value){
+    static check(name:string){
         const checkbox = document.querySelector<HTMLInputElement>(`#${name}-checkbox`);
         
         if(checkbox?.checked){
-            document.querySelector<HTMLInputElement>(`#${name}`).value = value;
+            document.querySelector<HTMLInputElement>(`#${name}`).value = "true";
         }
         else{
             document.querySelector<HTMLInputElement>(`#${name}`).value = "false";

--- a/src/Web/Scripts/CodeMirrorWrapper.ts
+++ b/src/Web/Scripts/CodeMirrorWrapper.ts
@@ -61,5 +61,7 @@ class CodeMirrorWrapper{
                 CodeMirror.commands.autocomplete(cm, CodeMirror.hint.hintList, { completeSingle: false });
             }
         });
+        
+        setTimeout(()=>{codeMirrorTextArea.refresh()},200)
     }
 }

--- a/src/Web/Scripts/CodeMirrorWrapper.ts
+++ b/src/Web/Scripts/CodeMirrorWrapper.ts
@@ -4,9 +4,15 @@ class CodeMirrorWrapperOptions{
     mode: string
     hintList: string
     hintKey: string
+    singleLine: boolean
 }
 
 class CodeMirrorWrapper{
+    private static isCodeMirrorConfigured(elementId) {
+        const textArea = document.querySelector("#"+elementId);
+        
+        return textArea.codeMirrorInstance != null;
+    }
     static setupCodeMirror(elementId: string, options: CodeMirrorWrapperOptions) {
         
         const textArea = document.querySelector("#"+elementId);
@@ -14,7 +20,8 @@ class CodeMirrorWrapper{
         if(!textArea)
             return;
         
-        console.log("hola")
+        if(this.isCodeMirrorConfigured(elementId))
+            return;
         
         const codeMirrorTextArea = CodeMirror.fromTextArea(textArea, {
             mode: options.mode,
@@ -22,12 +29,22 @@ class CodeMirrorWrapper{
             smartIndent: true,
             lineNumbers: true,
             autofocus: true,
-            autoRefresh: true,
             autohint: true,
             extraKeys: { "Ctrl-Space": "autocomplete" }
         });
-
-        codeMirrorTextArea.setSize(null, 250);
+        
+        if(options.singleLine){
+            codeMirrorTextArea.setSize(null, 30);
+            codeMirrorTextArea.on("beforeChange", function(instance, change) {
+                const newText = change.text.join("").replace(/\n/g, "");
+                change.update(change.from, change.to, [newText]);
+                return true;
+            });
+        }
+        else{
+            codeMirrorTextArea.setSize(null, 250);
+        }
+        textArea.codeMirrorInstance = codeMirrorTextArea;
         
         // @ts-ignore
         CodeMirror.registerHelper('hint', 'hintList', function (_) {

--- a/src/Web/Scripts/ExpressionTagHelper.ts
+++ b/src/Web/Scripts/ExpressionTagHelper.ts
@@ -1,0 +1,32 @@
+function listenExpressionType(name, hintList) {
+    document.getElementById(name + '-ExpressionType').addEventListener('change', function () {
+        const selectedType = (this as HTMLInputElement).value;
+        const expressionValueInput = document.getElementById(name + '-ExpressionValue') as HTMLInputElement;
+        if (selectedType === 'sql') {
+            const textArea = document.createElement('textarea');
+            textArea.setAttribute('name', name + '-ExpressionValue');
+            textArea.setAttribute('id', name + '-ExpressionValue');
+            textArea.setAttribute('class', 'form-control');
+            textArea.innerText = expressionValueInput.value;
+            expressionValueInput.outerHTML = textArea.outerHTML;
+            CodeMirrorWrapper.setupCodeMirror(name + '-ExpressionValue', { mode: 'text/x-sql', singleLine: true, hintList: hintList, hintKey: '{' });
+        } else {
+            const input = document.createElement('input');
+            input.setAttribute('type', 'text');
+            input.setAttribute('class', 'form-control');
+            input.setAttribute('name', name + '-ExpressionValue');
+            input.setAttribute('id', name + '-ExpressionValue');
+            input.value = expressionValueInput.value;
+
+            // @ts-ignore
+            if (expressionValueInput.codeMirrorInstance) {
+                // @ts-ignore
+                expressionValueInput.codeMirrorInstance.setOption('mode', 'text/x-csrc');
+                // @ts-ignore
+                expressionValueInput.codeMirrorInstance.getWrapperElement().parentNode.removeChild(expressionValueInput.codeMirrorInstance.getWrapperElement());
+            }
+
+            expressionValueInput.outerHTML = input.outerHTML;
+        }
+    });
+}

--- a/src/Web/Scripts/ExpressionTagHelper.ts
+++ b/src/Web/Scripts/ExpressionTagHelper.ts
@@ -23,20 +23,25 @@ function listenExpressionType(name, hintList, isBoolean) {
             const input = document.createElement('input') as HTMLInputElement;
             input.name = expressionValueInputName;
             input.id = expressionValueInputName;
-            input.hidden = true;
+            input.setAttribute("value","false")
+            input.setAttribute("hidden","hidden")
 
             const checkbox = document.createElement('input') as HTMLInputElement;
             checkbox.name = name + '-ExpressionValue-checkbox';
             checkbox.id = name + '-ExpressionValue-checkbox';
             checkbox.type = 'checkbox';
-            checkbox.onchange = ()=>CheckboxHelper.check(expressionValueInputName);
-            checkbox.setAttribute('role', 'switch');
+            checkbox.setAttribute("role", 'switch');
+            checkbox.setAttribute("value","false");
+            checkbox.setAttribute("onchange",`CheckboxHelper.check('${expressionValueInputName}')`)
             checkbox.classList.add('form-check-input');
-
+            
             div.appendChild(input);
             div.appendChild(checkbox);
-
+            
+            
             expressionValueEditor.innerHTML = div.outerHTML;
+            
+
         }
         else {
             const input = document.createElement('input');

--- a/src/Web/Scripts/ExpressionTagHelper.ts
+++ b/src/Web/Scripts/ExpressionTagHelper.ts
@@ -1,16 +1,44 @@
-function listenExpressionType(name, hintList) {
+function listenExpressionType(name, hintList, isBoolean) {
     document.getElementById(name + '-ExpressionType').addEventListener('change', function () {
         const selectedType = (this as HTMLInputElement).value;
         const expressionValueInput = document.getElementById(name + '-ExpressionValue') as HTMLInputElement;
-        if (selectedType === 'sql') {
+        const expressionValueEditor = document.getElementById(name + '-ExpressionValueEditor') as HTMLInputElement;
+        
+        if (selectedType === 'sql' || selectedType == 'exp') {
             const textArea = document.createElement('textarea');
             textArea.setAttribute('name', name + '-ExpressionValue');
             textArea.setAttribute('id', name + '-ExpressionValue');
             textArea.setAttribute('class', 'form-control');
             textArea.innerText = expressionValueInput.value;
-            expressionValueInput.outerHTML = textArea.outerHTML;
+            expressionValueEditor.innerHTML = textArea.outerHTML;
             CodeMirrorWrapper.setupCodeMirror(name + '-ExpressionValue', { mode: 'text/x-sql', singleLine: true, hintList: hintList, hintKey: '{' });
-        } else {
+        } 
+        else if(selectedType ==='val' && isBoolean){
+            const div = document.createElement('div');
+            div.classList.add('form-switch', 'form-switch-md', 'form-check');
+
+            
+            const expressionValueInputName = name + '-ExpressionValue';
+            
+            const input = document.createElement('input') as HTMLInputElement;
+            input.name = expressionValueInputName;
+            input.id = expressionValueInputName;
+            input.hidden = true;
+
+            const checkbox = document.createElement('input') as HTMLInputElement;
+            checkbox.name = name + '-ExpressionValue-checkbox';
+            checkbox.id = name + '-ExpressionValue-checkbox';
+            checkbox.type = 'checkbox';
+            checkbox.onchange = ()=>CheckboxHelper.check(expressionValueInputName);
+            checkbox.setAttribute('role', 'switch');
+            checkbox.classList.add('form-check-input');
+
+            div.appendChild(input);
+            div.appendChild(checkbox);
+
+            expressionValueEditor.innerHTML = div.outerHTML;
+        }
+        else {
             const input = document.createElement('input');
             input.setAttribute('type', 'text');
             input.setAttribute('class', 'form-control');
@@ -26,7 +54,7 @@ function listenExpressionType(name, hintList) {
                 expressionValueInput.codeMirrorInstance.getWrapperElement().parentNode.removeChild(expressionValueInput.codeMirrorInstance.getWrapperElement());
             }
 
-            expressionValueInput.outerHTML = input.outerHTML;
+            expressionValueEditor.innerHTML = input.outerHTML;
         }
     });
 }

--- a/src/Web/Scripts/Utils.ts
+++ b/src/Web/Scripts/Utils.ts
@@ -138,3 +138,11 @@ function requestSubmitParentWindow() {
 }
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function onDOMReady(callback) {
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', callback);
+    } else {
+        callback();
+    }
+}

--- a/src/Web/TagHelpers/ExpressionTagHelper.cs
+++ b/src/Web/TagHelpers/ExpressionTagHelper.cs
@@ -1,0 +1,171 @@
+using System.Web;
+using JJMasterData.Commons.Localization;
+using JJMasterData.Core.DataDictionary;
+using JJMasterData.Core.DataDictionary.Models;
+using JJMasterData.Core.DataManager.Expressions;
+using JJMasterData.Core.DataManager.Expressions.Abstractions;
+using JJMasterData.Core.UI;
+using JJMasterData.Core.UI.Components;
+using JJMasterData.Core.UI.Html;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Localization;
+
+namespace JJMasterData.Web.TagHelpers;
+
+public class ExpressionTagHelper : TagHelper
+{
+    private IEnumerable<IExpressionProvider> ExpressionProviders { get; }
+    private readonly IStringLocalizer<JJMasterDataResources> _stringLocalizer;
+    private readonly IComponentFactory<JJCard> _cardFactory;
+
+    [HtmlAttributeName("for")]
+    public ModelExpression For { get; set; } = null!;
+
+    [HtmlAttributeName("tooltip")]
+    public string? Tooltip { get; set; }
+
+
+    [ViewContext]
+    [HtmlAttributeNotBound] 
+    public ViewContext ViewContext { get; set; } = null!;
+    
+    public ExpressionTagHelper(
+        IStringLocalizer<JJMasterDataResources> stringLocalizer,
+        IEnumerable<IExpressionProvider> expressionProviders,
+        ExpressionParser expressionParser,
+        IComponentFactory<JJCard> cardFactory)
+    {
+        ExpressionProviders = expressionProviders;
+        _stringLocalizer = stringLocalizer;
+        _cardFactory = cardFactory;
+    }
+
+    public override void Process(TagHelperContext context, TagHelperOutput output)
+    {
+        var name = For.Name;
+        var value = For.Model?.ToString();
+        var selectedExpressionType = value?.Split(':')[0];
+        var selectedExpressionValue = value?.Split(':')[1]  ?? string.Empty;
+        
+        var card = _cardFactory.Create();
+        card.Layout = PanelLayout.Collapse;
+        card.Title = _stringLocalizer[name];
+        card.HtmlBuilderContent.Append(HtmlTag.Div, div =>
+        {
+            div.WithCssClass("row");
+            div.Append(HtmlTag.Div, div =>
+            {
+                div.WithCssClass("col-sm-2");
+                div.Append(HtmlTag.Label, label =>
+                {
+                    label.WithCssClass("form-label");
+                    label.WithAttribute("for", name + "-ExpressionType");
+                    label.AppendText("Type");
+                });
+                
+                div.Append(HtmlTag.Select, select =>
+                {
+                    select.WithNameAndId( name + "-ExpressionType");
+                    select.WithCssClass("form-select");
+
+                    foreach (var provider in ExpressionProviders.Select(s => s.Prefix))
+                    {
+                        select.Append(HtmlTag.Option, option =>
+                        {
+                            if (selectedExpressionType == provider)
+                            {
+                                option.WithAttribute("selected", "selected");
+                            }
+                            option.AppendText(provider);
+                        });
+                    }
+                });
+            });
+
+            div.Append(HtmlTag.Div, div =>
+            {
+                div.WithCssClass("col-sm-10");
+                div.Append(HtmlTag.Label, label =>
+                {
+                    label.WithCssClass("form-label");
+                    label.WithAttribute("for", name + "-ExpressionValue");
+                    label.AppendText("Expression");
+                });
+                
+                if (Tooltip is not null)
+                {
+                    var icon = new JJIcon(IconType.QuestionCircle);
+                    icon.CssClass += " help-description";
+                    icon.Attributes["title"] = Tooltip;
+                    icon.Attributes[BootstrapHelper.DataToggle] = "tooltip";
+                    div.AppendComponent(icon);
+                }
+
+                if (selectedExpressionType == "sql")
+                {
+                    div.Append(HtmlTag.TextArea, textArea =>
+                    {
+                        textArea.WithNameAndId( name + "-ExpressionValue");
+                        textArea.AppendText(selectedExpressionValue);
+                    });
+
+                    div.AppendScript(
+                        $"onDOMReady(()=>{{CodeMirrorWrapper.setupCodeMirror('{name}-ExpressionValue',{{mode: 'text/x-sql',singleLine:true, hintList: {ViewContext.ViewBag.CodeMirrorHintList}, hintKey: '{{'}});}})");
+                }
+                else
+                {   
+                    div.Append(HtmlTag.Input, input =>
+                    {
+                        input.WithNameAndId( name + "-ExpressionValue");
+                        input.WithValue(selectedExpressionValue);
+                        input.WithCssClass("form-control");
+                    });
+                    
+                }
+                
+            });
+        });
+        
+                
+        output.TagMode = TagMode.StartTagAndEndTag;
+        
+        output.Content.SetHtmlContent(card.GetHtml());
+        output.PostElement.SetHtmlContent(@$"
+    <script>
+    document.getElementById('{name}-ExpressionType').addEventListener('change', function () {{
+        const selectedType = this.value;
+        const expressionValueInput = document.getElementById('{name}-ExpressionValue');
+        if (selectedType === 'sql') {{
+            const textArea = document.createElement('textarea');
+            textArea.setAttribute('name', '{name}-ExpressionValue');
+            textArea.setAttribute('id', '{name}-ExpressionValue');
+            textArea.setAttribute('class', 'form-control');
+            textArea.innerText = expressionValueInput.value;
+            expressionValueInput.outerHTML = textArea.outerHTML;
+            CodeMirrorWrapper.setupCodeMirror('{name}-ExpressionValue', {{ mode: 'text/x-sql',singleLine:true, hintList: " + ViewContext.ViewBag.CodeMirrorHintList + @$", hintKey: '{{' }});
+        }} else {{
+            const input = document.createElement('input');
+            input.setAttribute('type', 'text');
+            input.setAttribute('class', 'form-control');
+            input.setAttribute('name', '{name}-ExpressionValue');
+            input.setAttribute('id', '{name}-ExpressionValue');
+            input.value = expressionValueInput.value;
+
+            if(expressionValueInput.codeMirrorInstance){{
+                expressionValueInput.codeMirrorInstance.setOption('mode', 'text/x-csrc');
+                expressionValueInput.codeMirrorInstance.getWrapperElement().parentNode.removeChild(expressionValueInput.codeMirrorInstance.getWrapperElement());
+            }}
+
+            expressionValueInput.outerHTML = input.outerHTML;
+           
+        }}
+    }});
+    </script>
+");
+    }
+    
+}

--- a/src/Web/TagHelpers/ExpressionTagHelper.cs
+++ b/src/Web/TagHelpers/ExpressionTagHelper.cs
@@ -50,6 +50,7 @@ public class ExpressionTagHelper : TagHelper
         var value = For.Model?.ToString();
         var selectedExpressionType = value?.Split(':')[0];
         var selectedExpressionValue = value?.Split(':')[1]  ?? string.Empty;
+        string codeMirrorHintList = ViewContext.ViewBag.CodeMirrorHintList;
         
         var card = _cardFactory.Create();
         card.Layout = PanelLayout.Collapse;
@@ -114,7 +115,7 @@ public class ExpressionTagHelper : TagHelper
                     });
 
                     div.AppendScript(
-                        $"onDOMReady(()=>{{CodeMirrorWrapper.setupCodeMirror('{name}-ExpressionValue',{{mode: 'text/x-sql',singleLine:true, hintList: {ViewContext.ViewBag.CodeMirrorHintList}, hintKey: '{{'}});}})");
+                        $"onDOMReady(()=>{{CodeMirrorWrapper.setupCodeMirror('{name}-ExpressionValue',{{mode: 'text/x-sql',singleLine:true, hintList: {codeMirrorHintList}, hintKey: '{{'}});}})");
                 }
                 else
                 {   
@@ -129,43 +130,14 @@ public class ExpressionTagHelper : TagHelper
                 
             });
         });
+
+        var html = card.GetHtmlBuilder();
+
+        html.AppendScript($"listenExpressionType('{name}',{codeMirrorHintList})");
         
-                
         output.TagMode = TagMode.StartTagAndEndTag;
         
-        output.Content.SetHtmlContent(card.GetHtml());
-        output.PostElement.SetHtmlContent(@$"
-    <script>
-    document.getElementById('{name}-ExpressionType').addEventListener('change', function () {{
-        const selectedType = this.value;
-        const expressionValueInput = document.getElementById('{name}-ExpressionValue');
-        if (selectedType === 'sql') {{
-            const textArea = document.createElement('textarea');
-            textArea.setAttribute('name', '{name}-ExpressionValue');
-            textArea.setAttribute('id', '{name}-ExpressionValue');
-            textArea.setAttribute('class', 'form-control');
-            textArea.innerText = expressionValueInput.value;
-            expressionValueInput.outerHTML = textArea.outerHTML;
-            CodeMirrorWrapper.setupCodeMirror('{name}-ExpressionValue', {{ mode: 'text/x-sql',singleLine:true, hintList: " + ViewContext.ViewBag.CodeMirrorHintList + @$", hintKey: '{{' }});
-        }} else {{
-            const input = document.createElement('input');
-            input.setAttribute('type', 'text');
-            input.setAttribute('class', 'form-control');
-            input.setAttribute('name', '{name}-ExpressionValue');
-            input.setAttribute('id', '{name}-ExpressionValue');
-            input.value = expressionValueInput.value;
-
-            if(expressionValueInput.codeMirrorInstance){{
-                expressionValueInput.codeMirrorInstance.setOption('mode', 'text/x-csrc');
-                expressionValueInput.codeMirrorInstance.getWrapperElement().parentNode.removeChild(expressionValueInput.codeMirrorInstance.getWrapperElement());
-            }}
-
-            expressionValueInput.outerHTML = input.outerHTML;
-           
-        }}
-    }});
-    </script>
-");
+        output.Content.SetHtmlContent(html.ToString());
     }
     
 }

--- a/src/Web/TagHelpers/ExpressionTagHelper.cs
+++ b/src/Web/TagHelpers/ExpressionTagHelper.cs
@@ -39,7 +39,7 @@ public class ExpressionTagHelper : TagHelper
     [HtmlAttributeNotBound]
     public ViewContext ViewContext { get; set; } = null!;
     
-
+    
     public ExpressionTagHelper(
         IStringLocalizer<JJMasterDataResources> stringLocalizer,
         IEnumerable<IExpressionProvider> expressionProviders,
@@ -95,9 +95,12 @@ public class ExpressionTagHelper : TagHelper
         {
             select.WithNameAndId(name + "-ExpressionType");
             select.WithCssClass("form-select");
-
+            
             foreach (var provider in ExpressionProviders)
             {
+                if (IsBoolean && provider.Prefix != "val" && provider.Prefix != "exp")
+                    continue;
+                
                 select.Append(HtmlTag.Option, option =>
                 {
                     if (selectedExpressionType == provider.Prefix)

--- a/src/Web/TagHelpers/ExpressionTagHelper.cs
+++ b/src/Web/TagHelpers/ExpressionTagHelper.cs
@@ -96,16 +96,17 @@ public class ExpressionTagHelper : TagHelper
             select.WithNameAndId(name + "-ExpressionType");
             select.WithCssClass("form-select");
 
-            foreach (var provider in ExpressionProviders.Select(s => s.Prefix))
+            foreach (var provider in ExpressionProviders)
             {
                 select.Append(HtmlTag.Option, option =>
                 {
-                    if (selectedExpressionType == provider)
+                    if (selectedExpressionType == provider.Prefix)
                     {
                         option.WithAttribute("selected", "selected");
                     }
 
-                    option.AppendText(provider);
+                    option.WithValue(provider.Prefix);
+                    option.AppendText(provider.Title);
                 });
             }
         });

--- a/src/Web/TagHelpers/ExpressionTagHelper.cs
+++ b/src/Web/TagHelpers/ExpressionTagHelper.cs
@@ -31,11 +31,15 @@ public class ExpressionTagHelper : TagHelper
 
     [HtmlAttributeName("is-boolean")] 
     public bool IsBoolean { get; set; } = true;
-
+    
+    [HtmlAttributeName("icon")] 
+    public IconType? Icon { get; set; }
+    
     [ViewContext]
-    [HtmlAttributeNotBound] 
+    [HtmlAttributeNotBound]
     public ViewContext ViewContext { get; set; } = null!;
     
+
     public ExpressionTagHelper(
         IStringLocalizer<JJMasterDataResources> stringLocalizer,
         IEnumerable<IExpressionProvider> expressionProviders,
@@ -57,7 +61,8 @@ public class ExpressionTagHelper : TagHelper
         
         var card = _cardFactory.Create();
         card.Layout = PanelLayout.Collapse;
-        card.Title = _stringLocalizer[name];
+        card.Icon = Icon;
+        card.Title = For.ModelExplorer.Metadata.GetDisplayName();
         card.HtmlBuilderContent.Append(HtmlTag.Div, div =>
         {
             div.WithCssClass("row");
@@ -166,7 +171,7 @@ public class ExpressionTagHelper : TagHelper
                     });
 
                     div.AppendScript(
-                        $"onDOMReady(()=>{{CodeMirrorWrapper.setupCodeMirror('{name}-ExpressionValue',{{mode: 'text/x-sql',singleLine:true, hintList: {codeMirrorHintList}, hintKey: '{{'}});}})");
+                        @$"onDOMReady(()=>{{CodeMirrorWrapper.setupCodeMirror('{name}-ExpressionValue',{{mode: 'text/x-sql',singleLine:true, hintList: {codeMirrorHintList}, hintKey: '{{'}});}})");
                 }
                 else
                 {

--- a/src/Web/Views/Shared/_MasterDataStylesheets.cshtml
+++ b/src/Web/Views/Shared/_MasterDataStylesheets.cshtml
@@ -30,7 +30,7 @@
 <environment exclude="Development">
     @if (Options.Value.UseCustomBootstrap)
     {
-        <link rel="stylesheet" href="@Options.Value.CustomBootstrapPath"/>
+        <link rel="stylesheet" href="@Options.Value.CustomBootstrapPath"  asp-append-version="true"/>
         <link rel="stylesheet" href="~/css/jjmasterdata-bundle.min.css" asp-append-version="true"/>
     }
     else

--- a/src/Web/Web.csproj
+++ b/src/Web/Web.csproj
@@ -21,7 +21,6 @@
     <ItemGroup>
         <PackageReference Include="LigerShark.WebOptimizer.Core" Version="3.0.396" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.8" />
-        <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.7" />
         <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
         <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="4.7.4">
           <PrivateAssets>all</PrivateAssets>
@@ -34,6 +33,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)' == 'Debug'">
+        <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.7" />
         <EmbeddedResource Include="Scripts\**\*.ts" />
     </ItemGroup>
     

--- a/src/Web/wwwroot/js/jjmasterdata/jjmasterdata.js
+++ b/src/Web/wwwroot/js/jjmasterdata/jjmasterdata.js
@@ -285,6 +285,7 @@ class CodeMirrorWrapper {
                 CodeMirror.commands.autocomplete(cm, CodeMirror.hint.hintList, { completeSingle: false });
             }
         });
+        setTimeout(() => { codeMirrorTextArea.refresh(); }, 200);
     }
 }
 class CollapsePanelListener {

--- a/src/Web/wwwroot/js/jjmasterdata/jjmasterdata.js
+++ b/src/Web/wwwroot/js/jjmasterdata/jjmasterdata.js
@@ -819,6 +819,34 @@ function applyDecimalPlaces() {
     else
         $(this).number(true, decimalPlaces);
 }
+function listenExpressionType(name, hintList) {
+    document.getElementById(name + '-ExpressionType').addEventListener('change', function () {
+        const selectedType = this.value;
+        const expressionValueInput = document.getElementById(name + '-ExpressionValue');
+        if (selectedType === 'sql') {
+            const textArea = document.createElement('textarea');
+            textArea.setAttribute('name', name + '-ExpressionValue');
+            textArea.setAttribute('id', name + '-ExpressionValue');
+            textArea.setAttribute('class', 'form-control');
+            textArea.innerText = expressionValueInput.value;
+            expressionValueInput.outerHTML = textArea.outerHTML;
+            CodeMirrorWrapper.setupCodeMirror(name + '-ExpressionValue', { mode: 'text/x-sql', singleLine: true, hintList: hintList, hintKey: '{' });
+        }
+        else {
+            const input = document.createElement('input');
+            input.setAttribute('type', 'text');
+            input.setAttribute('class', 'form-control');
+            input.setAttribute('name', name + '-ExpressionValue');
+            input.setAttribute('id', name + '-ExpressionValue');
+            input.value = expressionValueInput.value;
+            if (expressionValueInput.codeMirrorInstance) {
+                expressionValueInput.codeMirrorInstance.setOption('mode', 'text/x-csrc');
+                expressionValueInput.codeMirrorInstance.getWrapperElement().parentNode.removeChild(expressionValueInput.codeMirrorInstance.getWrapperElement());
+            }
+            expressionValueInput.outerHTML = input.outerHTML;
+        }
+    });
+}
 class FeedbackIcon {
     static removeAllIcons(selector) {
         const elements = window.parent.document.querySelectorAll(selector);

--- a/src/Web/wwwroot/js/jjmasterdata/jjmasterdata.js
+++ b/src/Web/wwwroot/js/jjmasterdata/jjmasterdata.js
@@ -840,13 +840,15 @@ function listenExpressionType(name, hintList, isBoolean) {
             const input = document.createElement('input');
             input.name = expressionValueInputName;
             input.id = expressionValueInputName;
-            input.hidden = true;
+            input.setAttribute("value", "false");
+            input.setAttribute("hidden", "hidden");
             const checkbox = document.createElement('input');
             checkbox.name = name + '-ExpressionValue-checkbox';
             checkbox.id = name + '-ExpressionValue-checkbox';
             checkbox.type = 'checkbox';
-            checkbox.onchange = () => CheckboxHelper.check(expressionValueInputName);
-            checkbox.setAttribute('role', 'switch');
+            checkbox.setAttribute("role", 'switch');
+            checkbox.setAttribute("value", "false");
+            checkbox.setAttribute("onchange", `CheckboxHelper.check('${expressionValueInputName}')`);
             checkbox.classList.add('form-check-input');
             div.appendChild(input);
             div.appendChild(checkbox);

--- a/src/Web/wwwroot/js/jjmasterdata/jjmasterdata.js
+++ b/src/Web/wwwroot/js/jjmasterdata/jjmasterdata.js
@@ -228,10 +228,10 @@ class CalendarListener {
     }
 }
 class CheckboxHelper {
-    static check(name, value) {
+    static check(name) {
         const checkbox = document.querySelector(`#${name}-checkbox`);
         if (checkbox === null || checkbox === void 0 ? void 0 : checkbox.checked) {
-            document.querySelector(`#${name}`).value = value;
+            document.querySelector(`#${name}`).value = "true";
         }
         else {
             document.querySelector(`#${name}`).value = "false";
@@ -819,18 +819,38 @@ function applyDecimalPlaces() {
     else
         $(this).number(true, decimalPlaces);
 }
-function listenExpressionType(name, hintList) {
+function listenExpressionType(name, hintList, isBoolean) {
     document.getElementById(name + '-ExpressionType').addEventListener('change', function () {
         const selectedType = this.value;
         const expressionValueInput = document.getElementById(name + '-ExpressionValue');
-        if (selectedType === 'sql') {
+        const expressionValueEditor = document.getElementById(name + '-ExpressionValueEditor');
+        if (selectedType === 'sql' || selectedType == 'exp') {
             const textArea = document.createElement('textarea');
             textArea.setAttribute('name', name + '-ExpressionValue');
             textArea.setAttribute('id', name + '-ExpressionValue');
             textArea.setAttribute('class', 'form-control');
             textArea.innerText = expressionValueInput.value;
-            expressionValueInput.outerHTML = textArea.outerHTML;
+            expressionValueEditor.innerHTML = textArea.outerHTML;
             CodeMirrorWrapper.setupCodeMirror(name + '-ExpressionValue', { mode: 'text/x-sql', singleLine: true, hintList: hintList, hintKey: '{' });
+        }
+        else if (selectedType === 'val' && isBoolean) {
+            const div = document.createElement('div');
+            div.classList.add('form-switch', 'form-switch-md', 'form-check');
+            const expressionValueInputName = name + '-ExpressionValue';
+            const input = document.createElement('input');
+            input.name = expressionValueInputName;
+            input.id = expressionValueInputName;
+            input.hidden = true;
+            const checkbox = document.createElement('input');
+            checkbox.name = name + '-ExpressionValue-checkbox';
+            checkbox.id = name + '-ExpressionValue-checkbox';
+            checkbox.type = 'checkbox';
+            checkbox.onchange = () => CheckboxHelper.check(expressionValueInputName);
+            checkbox.setAttribute('role', 'switch');
+            checkbox.classList.add('form-check-input');
+            div.appendChild(input);
+            div.appendChild(checkbox);
+            expressionValueEditor.innerHTML = div.outerHTML;
         }
         else {
             const input = document.createElement('input');
@@ -843,7 +863,7 @@ function listenExpressionType(name, hintList) {
                 expressionValueInput.codeMirrorInstance.setOption('mode', 'text/x-csrc');
                 expressionValueInput.codeMirrorInstance.getWrapperElement().parentNode.removeChild(expressionValueInput.codeMirrorInstance.getWrapperElement());
             }
-            expressionValueInput.outerHTML = input.outerHTML;
+            expressionValueEditor.innerHTML = input.outerHTML;
         }
     });
 }

--- a/src/Web/wwwroot/js/jjmasterdata/jjmasterdata.js
+++ b/src/Web/wwwroot/js/jjmasterdata/jjmasterdata.js
@@ -241,22 +241,37 @@ class CheckboxHelper {
 class CodeMirrorWrapperOptions {
 }
 class CodeMirrorWrapper {
+    static isCodeMirrorConfigured(elementId) {
+        const textArea = document.querySelector("#" + elementId);
+        return textArea.codeMirrorInstance != null;
+    }
     static setupCodeMirror(elementId, options) {
         const textArea = document.querySelector("#" + elementId);
         if (!textArea)
             return;
-        console.log("hola");
+        if (this.isCodeMirrorConfigured(elementId))
+            return;
         const codeMirrorTextArea = CodeMirror.fromTextArea(textArea, {
             mode: options.mode,
             indentWithTabs: true,
             smartIndent: true,
             lineNumbers: true,
             autofocus: true,
-            autoRefresh: true,
             autohint: true,
             extraKeys: { "Ctrl-Space": "autocomplete" }
         });
-        codeMirrorTextArea.setSize(null, 250);
+        if (options.singleLine) {
+            codeMirrorTextArea.setSize(null, 30);
+            codeMirrorTextArea.on("beforeChange", function (instance, change) {
+                const newText = change.text.join("").replace(/\n/g, "");
+                change.update(change.from, change.to, [newText]);
+                return true;
+            });
+        }
+        else {
+            codeMirrorTextArea.setSize(null, 250);
+        }
+        textArea.codeMirrorInstance = codeMirrorTextArea;
         CodeMirror.registerHelper('hint', 'hintList', function (_) {
             const cur = codeMirrorTextArea.getCursor();
             return {
@@ -2364,4 +2379,12 @@ function requestSubmitParentWindow() {
     window.parent.document.forms[0].requestSubmit();
 }
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+function onDOMReady(callback) {
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', callback);
+    }
+    else {
+        callback();
+    }
+}
 //# sourceMappingURL=jjmasterdata.js.map

--- a/test/Core.Test/DataManager/Expressions/ExpressionParserTests.cs
+++ b/test/Core.Test/DataManager/Expressions/ExpressionParserTests.cs
@@ -2,6 +2,7 @@ using JJMasterData.Core.DataDictionary.Models;
 using JJMasterData.Core.DataManager.Expressions;
 using JJMasterData.Core.DataManager.Models;
 using JJMasterData.Core.Http.Abstractions;
+using Microsoft.Extensions.Logging;
 using Moq;
 
 namespace JJMasterData.Core.Test.DataManager.Expressions;
@@ -14,7 +15,8 @@ public class ExpressionParserTests
     public ExpressionParserTests()
     {
         var httpContext = new Mock<IHttpContext>();
-        ExpressionParser = new ExpressionParser(httpContext.Object);
+        var logger = new Mock<ILogger<ExpressionParser>>();
+        ExpressionParser = new ExpressionParser(httpContext.Object,logger.Object);
     }
     
     [Fact]


### PR DESCRIPTION
```html
            <div class="@BootstrapHelper.FormGroup col-sm-12 required">
                    <expression for="VisibleExpression" tooltip="Boolean expression to show the field. Check expressions at the docs for more information."/>
                </div>
                <div class="@BootstrapHelper.FormGroup col-sm-12 required">
                     <expression for="EnableExpression" tooltip="Boolean expression to enable the field. Check expressions at the docs for more information."/>
                </div>
                <div class="@BootstrapHelper.FormGroup col-sm-12">
                    <expression for="TriggerExpression" tooltip="Expression triggered whenever a field triggers a POST to the server. Check expressions at the docs for more information."/>
                </div>
```

![image](https://github.com/JJConsulting/JJMasterData/assets/52143624/7745faa0-a255-4338-a2c1-a734fe915b09)

![image](https://github.com/JJConsulting/JJMasterData/assets/52143624/8086ad96-850d-4c69-88d3-0f5550fd2c8a)

Using one line in SQL to prevent rules at database

This closes #8 