### PR TITLE
Add Compact Mode to GridView

### DIFF
--- a/src/Commons/Localization/MasterDataResources.pt-BR.resx
+++ b/src/Commons/Localization/MasterDataResources.pt-BR.resx
@@ -3737,4 +3737,7 @@
   <data name="C# Class" xml:space="preserve">
     <value>Classe C#</value>
   </data>
+  <data name="Is Compact" xml:space="preserve">
+    <value>É Compacta</value>
+  </data>
 </root>

--- a/src/Commons/Localization/MasterDataResources.pt-BR.resx
+++ b/src/Commons/Localization/MasterDataResources.pt-BR.resx
@@ -3737,7 +3737,7 @@
   <data name="C# Class" xml:space="preserve">
     <value>Classe C#</value>
   </data>
-  <data name="Is Compact" xml:space="preserve">
-    <value>É Compacta</value>
+  <data name="Compact Mode" xml:space="preserve">
+    <value>Modo Compacto</value>
   </data>
 </root>

--- a/src/Core/DataDictionary/Models/GridUI.cs
+++ b/src/Core/DataDictionary/Models/GridUI.cs
@@ -158,6 +158,6 @@ public class GridUI
     public bool UseVerticalLayoutAtFilter { get; set; } 
     
     [JsonProperty("isCompact")]
-    [Display(Name = "Is Compact")]
+    [Display(Name = "Compact Mode")]
     public bool IsCompact { get; set; }
 }

--- a/src/Core/DataDictionary/Models/GridUI.cs
+++ b/src/Core/DataDictionary/Models/GridUI.cs
@@ -156,4 +156,8 @@ public class GridUI
     [JsonProperty("useVerticalLayoutAtFilter")]
     [Display(Name = "Use Vertical Layout At Filter")]
     public bool UseVerticalLayoutAtFilter { get; set; } 
+    
+    [JsonProperty("isCompact")]
+    [Display(Name = "Is Compact")]
+    public bool IsCompact { get; set; }
 }

--- a/src/Core/DataDictionary/Structure/DataDictionaryFormElementFactory.cs
+++ b/src/Core/DataDictionary/Structure/DataDictionaryFormElementFactory.cs
@@ -32,6 +32,8 @@ public class DataDictionaryFormElementFactory(
 
         AddActions(formElement);
 
+        formElement.Options.Grid.IsCompact = true;
+        formElement.Options.Grid.RecordsPerPage = 10;
         formElement.Options.Grid.UseVerticalLayoutAtFilter = true;
 
         return formElement;
@@ -72,7 +74,6 @@ public class DataDictionaryFormElementFactory(
     {
         formElement.Options.GridToolbarActions.InsertAction.SetVisible(false);
         formElement.Options.GridToolbarActions.ExportAction.SetVisible(false);
-
         formElement.Options.GridTableActions.Clear();
 
         AddGridTableActions(formElement);

--- a/src/Core/UI/Components/GridView/GridFormSettings.cs
+++ b/src/Core/UI/Components/GridView/GridFormSettings.cs
@@ -17,7 +17,7 @@ internal class GridFormSettings(IHttpContext currentContext, IStringLocalizer<Ma
     private const string TableRowsStriped = "grid-view-table-rowstriped";
     private const string TableRowHover = "grid-view-table-rowhover";
     private const string TableIsHeaderFixed = "grid-view-table-header-fixed";
-
+    private const string TableIsCompact = "grid-view-table-is-compact";
     public GridSettings LoadFromForm()
     {
         var gridSettings = new GridSettings();
@@ -27,6 +27,7 @@ internal class GridFormSettings(IHttpContext currentContext, IStringLocalizer<Ma
         var tableRowsStriped = currentContext.Request[TableRowsStriped];
         var tableRowHover = currentContext.Request[TableRowHover];
         var tableIsHeaderFixed = currentContext.Request[TableIsHeaderFixed];
+        var tableIsCompact = currentContext.Request[TableIsCompact];
 
         if (int.TryParse(tableRegPerPage, out var totalPerPage))
             gridSettings.RecordsPerPage = totalPerPage;
@@ -38,7 +39,7 @@ internal class GridFormSettings(IHttpContext currentContext, IStringLocalizer<Ma
         gridSettings.ShowRowStriped = StringManager.ParseBool(tableRowsStriped);
         gridSettings.ShowRowHover = StringManager.ParseBool(tableRowHover);
         gridSettings.IsHeaderFixed = StringManager.ParseBool(tableIsHeaderFixed);
-
+        gridSettings.IsCompact = StringManager.ParseBool(tableIsCompact);
         return gridSettings;
     }
 
@@ -55,21 +56,21 @@ internal class GridFormSettings(IHttpContext currentContext, IStringLocalizer<Ma
 
         if (isPaginationEnabled)
         {
-            div.Append(GetPaginationElement(gridSettings));
+            div.Append(GetPaginationHtml(gridSettings));
         }
         else
         {
             div.AppendHiddenInput(TableTotalPerPage, gridSettings.RecordsPerPage.ToString());
         }
 
-        div.Append(GetShowBorderElement(gridSettings));
-        div.Append(GetShowRowsStripedElement(gridSettings));
-        div.Append(GetHighlightLineElement(gridSettings));
-
+        div.Append(GetShowBorderHtml(gridSettings));
+        div.Append(GetShowRowsStripedHtml(gridSettings));
+        div.Append(GetHighlightLineHtml(gridSettings));
+        div.Append(GetIsCompactHtml(gridSettings));
         return div;
     }
 
-    private HtmlBuilder GetHighlightLineElement(GridSettings gridSettings)
+    private HtmlBuilder GetHighlightLineHtml(GridSettings gridSettings)
     {
         var div = new HtmlBuilder(HtmlTag.Div)
             .WithCssClass($"{BootstrapHelper.FormGroup} row")
@@ -84,12 +85,30 @@ internal class GridFormSettings(IHttpContext currentContext, IStringLocalizer<Ma
             div.WithCssClass("col-sm-8");
             div.Append(GetDataToggleElement(TableRowHover, gridSettings.ShowRowHover));
         });
-
-
+        
         return div;
     }
 
-    private HtmlBuilder GetShowRowsStripedElement(GridSettings gridSettings)
+    private HtmlBuilder GetIsCompactHtml(GridSettings gridSettings)
+    {
+        var div = new HtmlBuilder(HtmlTag.Div)
+            .WithCssClass($"{BootstrapHelper.FormGroup} row")
+            .Append(HtmlTag.Label, label =>
+            {
+                label.WithAttribute("for", TableIsCompact);
+                label.WithCssClass("col-sm-4");
+                label.AppendText(stringLocalizer["Is Compact"]);
+            });
+        div.Append(HtmlTag.Div, div =>
+        {
+            div.WithCssClass("col-sm-8");
+            div.Append(GetDataToggleElement(TableIsCompact, gridSettings.IsCompact));
+        });
+        
+        return div;
+    }
+    
+    private HtmlBuilder GetShowRowsStripedHtml(GridSettings gridSettings)
     {
         var div = new HtmlBuilder(HtmlTag.Div)
             .WithCssClass($"{BootstrapHelper.FormGroup} row")
@@ -108,7 +127,7 @@ internal class GridFormSettings(IHttpContext currentContext, IStringLocalizer<Ma
         return div;
     }
 
-    private HtmlBuilder GetShowBorderElement(GridSettings gridSettings)
+    private HtmlBuilder GetShowBorderHtml(GridSettings gridSettings)
     {
         var div = new HtmlBuilder(HtmlTag.Div)
             .WithCssClass($"{BootstrapHelper.FormGroup} row")
@@ -128,7 +147,7 @@ internal class GridFormSettings(IHttpContext currentContext, IStringLocalizer<Ma
         return div;
     }
 
-    private HtmlBuilder GetPaginationElement(GridSettings gridSettings)
+    private HtmlBuilder GetPaginationHtml(GridSettings gridSettings)
     {
         var div = new HtmlBuilder(HtmlTag.Div)
             .WithCssClass($"{BootstrapHelper.FormGroup} row")
@@ -148,7 +167,7 @@ internal class GridFormSettings(IHttpContext currentContext, IStringLocalizer<Ma
         return div;
     }
 
-    private HtmlBuilder GetTotalPerPageSelectElement(GridSettings gridSettings)
+    private static HtmlBuilder GetTotalPerPageSelectElement(GridSettings gridSettings)
     {
         var select = new HtmlBuilder(HtmlTag.Select)
             .WithCssClass("form-control form-select")

--- a/src/Core/UI/Components/GridView/GridFormSettings.cs
+++ b/src/Core/UI/Components/GridView/GridFormSettings.cs
@@ -97,7 +97,7 @@ internal class GridFormSettings(IHttpContext currentContext, IStringLocalizer<Ma
             {
                 label.WithAttribute("for", TableIsCompact);
                 label.WithCssClass("col-sm-4");
-                label.AppendText(stringLocalizer["Is Compact"]);
+                label.AppendText(stringLocalizer["Compact Mode"]);
             });
         div.Append(HtmlTag.Div, div =>
         {

--- a/src/Core/UI/Components/GridView/GridSettings.cs
+++ b/src/Core/UI/Components/GridView/GridSettings.cs
@@ -21,6 +21,8 @@ public class GridSettings
     public bool ShowRowHover { get; set; } = true;
 
     public bool IsResponsive { get; set; } = true;
+    
+    public bool IsCompact { get; set; } = true;
 
     public bool IsHeaderFixed { get; set; }
 }

--- a/src/Core/UI/Components/GridView/GridTable.cs
+++ b/src/Core/UI/Components/GridView/GridTable.cs
@@ -20,6 +20,7 @@ internal class GridTable(JJGridView gridView)
         
         var table = new HtmlBuilder(HtmlTag.Table);
         table.WithCssClass("table");
+        table.WithCssClassIf(Settings.IsCompact, "table-sm");
         table.WithCssClassIf(Settings.ShowBorder, "table-bordered");
         table.WithCssClassIf(Settings.ShowRowHover, "table-hover");
         table.WithCssClassIf(Settings.ShowRowStriped, "table-striped");

--- a/src/Core/UI/Components/GridView/GridViewFactory.cs
+++ b/src/Core/UI/Components/GridView/GridViewFactory.cs
@@ -120,7 +120,7 @@ internal class GridViewFactory(IHttpContext currentContext,
         grid.MaintainValuesOnLoad = gridOptions.MaintainValuesOnLoad;
         grid.ShowPagging = gridOptions.ShowPagging;
         grid.ShowToolbar = gridOptions.ShowToolBar;
-
+        
         if (!GridFormSettings.HasFormValues(grid.CurrentContext) || !grid.ShowToolbar || !grid.ConfigAction.IsVisible)
         {
             GridSettings settings = null;
@@ -136,6 +136,7 @@ internal class GridViewFactory(IHttpContext currentContext,
                 settings.RecordsPerPage = gridOptions.RecordsPerPage;
                 settings.TotalPaginationButtons = gridOptions.TotalPaggingButton;
                 settings.IsHeaderFixed = gridOptions.HeaderFixed;
+                settings.IsCompact = gridOptions.IsCompact;
             }
 
             grid.CurrentSettings = settings;

--- a/src/Web/Areas/DataDictionary/Views/UIOptions/_GridView.cshtml
+++ b/src/Web/Areas/DataDictionary/Views/UIOptions/_GridView.cshtml
@@ -60,6 +60,10 @@
             <label class="@BootstrapHelper.Label" asp-for="Grid.ShowHeaderWhenEmpty"></label>
             <checkbox for="Grid.ShowHeaderWhenEmpty" switch="true"/>
         </div>
+        <div class="col-sm-4">
+            <label class="@BootstrapHelper.Label" asp-for="Grid.IsCompact"></label>
+            <checkbox for="Grid.IsCompact" switch="true"/>
+        </div>
     </div>
     
     <div class="row">

--- a/src/Web/wwwroot/css/jjmasterdata/jjmasterdata.css
+++ b/src/Web/wwwroot/css/jjmasterdata/jjmasterdata.css
@@ -764,3 +764,8 @@ input.form-control:read-only {
     --bs-btn-active-bg: #d4d4d4;
     --bs-btn-active-border-color: #8c8c8c;
 }
+
+/* Backport table-sm to Bootstrap 3 */
+.table-sm > :not(caption) > * > *{
+    padding: 0.25rem 0.25rem !important;
+}


### PR DESCRIPTION
Useful for reports :)

Option:
<img width="905" alt="image" src="https://github.com/JJConsulting/JJMasterData/assets/52143624/d981ce83-8b70-4da7-9831-a52258ed1f4a">

<img width="463" alt="image" src="https://github.com/JJConsulting/JJMasterData/assets/52143624/12ed9cd3-dcfe-451d-a63e-b58b2b9c0609">

With Compact Mode:
<img width="918" alt="image" src="https://github.com/JJConsulting/JJMasterData/assets/52143624/356869cd-f1f6-4494-8759-086ebb6475a7">

Without Compact Mode:
<img width="919" alt="image" src="https://github.com/JJConsulting/JJMasterData/assets/52143624/1357e80c-9bcd-4ef7-9fae-7a796ebeca7c">

Also because of this, changed the default of records at Data Dictionary home to 10, what do you think?

