### PR TITLE
Add GridAlignment property to FormElementField.cs

### DIFF
--- a/src/Commons/Localization/MasterDataResources.pt-BR.resx
+++ b/src/Commons/Localization/MasterDataResources.pt-BR.resx
@@ -3804,4 +3804,16 @@
   <data name="Search Icon" xml:space="preserve">
     <value>Pesquisar Ícone</value>
   </data>
+  <data name="Alignment At Grid" xml:space="preserve">
+    <value>Alinhamento na Grid</value>
+  </data>
+  <data name="Left" xml:space="preserve">
+    <value>Esquerda</value>
+  </data>
+  <data name="Center" xml:space="preserve">
+    <value>Centro</value>
+  </data>
+  <data name="Right" xml:space="preserve">
+    <value>Direita</value>
+  </data>
 </root>

--- a/src/Core/DataDictionary/Models/FormElementField.cs
+++ b/src/Core/DataDictionary/Models/FormElementField.cs
@@ -172,6 +172,10 @@ public class FormElementField : ElementField
     [JsonProperty("internalNotes")]
     public string? InternalNotes { get; set; }
     
+    [JsonProperty("gridAlignment")]
+    [Display(Name = "Alignment At Grid")]
+    public GridAlignment GridAlignment { get; set; } 
+    
     /// <summary>
     /// The field will be disabled but the value send to the server
     /// </summary>

--- a/src/Core/DataDictionary/Models/GridAlignment.cs
+++ b/src/Core/DataDictionary/Models/GridAlignment.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace JJMasterData.Core.DataDictionary.Models;
+
+public enum GridAlignment
+{
+    [Display(Name = "Default")]
+    Default,
+    [Display(Name = "Left")]
+    Left,
+    [Display(Name = "Center")]
+    Center,
+    [Display(Name = "Right")]
+    Right
+}

--- a/src/Core/DataDictionary/Structure/DataDictionaryFormElementFactory.cs
+++ b/src/Core/DataDictionary/Structure/DataDictionaryFormElementFactory.cs
@@ -67,6 +67,7 @@ public class DataDictionaryFormElementFactory(
         formElement.Fields[DataDictionaryStructure.Json].HelpDescription =
             StringLocalizer["Filter by any data within the data dictionary structure."];
         formElement.Fields[DataDictionaryStructure.LastModified].Component = FormComponent.DateTime;
+        formElement.Fields[DataDictionaryStructure.LastModified].GridAlignment = GridAlignment.Right;
         formElement.Fields[DataDictionaryStructure.EnableSynchronism].VisibleExpression = "val:0";
         formElement.Fields[DataDictionaryStructure.EnableSynchronism].Component = FormComponent.CheckBox;
     }

--- a/src/Core/UI/Components/GridView/GridTableBody.cs
+++ b/src/Core/UI/Components/GridView/GridTableBody.cs
@@ -303,6 +303,15 @@ internal class GridTableBody(JJGridView gridView)
 
     private static string GetTdStyle(FormElementField field)
     {
+        switch (field.GridAlignment)
+        {
+            case GridAlignment.Left:
+                return "text-align:left";
+            case GridAlignment.Center:
+                return "text-align:center";
+            case GridAlignment.Right:
+                return "text-align:right";
+        }
         switch (field.Component)
         {
             case FormComponent.ComboBox or FormComponent.RadioButtonGroup:

--- a/src/Core/UI/Components/GridView/GridTableHeader.cs
+++ b/src/Core/UI/Components/GridView/GridTableHeader.cs
@@ -60,7 +60,7 @@ internal class GridTableHeader
         await foreach (var field in GridView.GetVisibleFieldsAsync())
         {
             var th = new HtmlBuilder(HtmlTag.Th);
-            string style = GetFieldStyle(field);
+            string style = GetThStyle(field);
 
             th.WithAttributeIfNotEmpty("style", style);
             th.Append(HtmlTag.Span, span =>
@@ -142,39 +142,44 @@ internal class GridTableHeader
     private HtmlBuilder GetDescendingIcon() => new JJIcon("fa fa-sort-amount-desc").GetHtmlBuilder()
         .WithToolTip(StringLocalizer["Descending order"]);
 
-    private static string GetFieldStyle(FormElementField field)
+    private static string GetThStyle(FormElementField field)
     {
-        string style = string.Empty;
+        switch (field.GridAlignment)
+        {
+            case GridAlignment.Left:
+                return "text-align:left";
+            case GridAlignment.Center:
+                return "text-align:center";
+            case GridAlignment.Right:
+                return "text-align:right";
+        }
         switch (field.Component)
         {
             case FormComponent.ComboBox or FormComponent.RadioButtonGroup:
             {
-                if (field.DataItem is { ShowIcon: true, GridBehavior: DataItemGridBehavior.Icon or DataItemGridBehavior.IconWithDescription })
-                {
-                    style = "text-align:center";
-                }
+                if (field.DataItem is { 
+                        ShowIcon: true,
+                        GridBehavior: DataItemGridBehavior.Icon or DataItemGridBehavior.IconWithDescription 
+                    })
+                    return "text-align:center";
 
                 break;
             }
             case FormComponent.CheckBox:
-                style = "text-align:center;width:60px;";
-                break;
-            case FormComponent.Cnpj:
-                style = "min-width:130px;";
-                break;
+                return "text-align:center;";
             default:
             {
                 if (field.DataType is FieldType.Float or FieldType.Int)
                 {
                     if (!field.IsPk)
-                        style = "text-align:right;";
+                        return "text-align:right;";
                 }
 
                 break;
             }
         }
 
-        return style;
+        return string.Empty;
     }
 
     private HtmlBuilder GetMultSelectThHtmlElement()

--- a/src/Web/Areas/DataDictionary/Views/Field/_Detail.cshtml
+++ b/src/Web/Areas/DataDictionary/Views/Field/_Detail.cshtml
@@ -168,6 +168,12 @@
 
                     @Html.TextBoxFor(model => model.LineGroup, new { type = "number", @class = "form-control" })
                 </div>
+                
+                <div class="@BootstrapHelper.FormGroup col-sm-3 required">
+                    <label class="@BootstrapHelper.Label " asp-for="GridAlignment"></label>
+                    <select asp-for="GridAlignment"  class="form-control form-select" asp-items="Html.GetEnumSelectList<GridAlignment>()"></select>
+                </div>
+                
                 <div class="@BootstrapHelper.FormGroup col-sm-3 required">
                     <label class="@BootstrapHelper.Label " asp-for="Export"></label>
                     <checkbox for="Export" switch="true"/>


### PR DESCRIPTION
This is not a true combobox (OnRenderCell), and I wanted this field at the center.
<img width="221" alt="image" src="https://github.com/JJConsulting/JJMasterData/assets/52143624/c05f2f0c-e8dc-419a-bb9c-4290b7f1404f">
<br>

<img width="62" alt="image" src="https://github.com/JJConsulting/JJMasterData/assets/52143624/9482f84e-dbac-453a-8add-16bb2d986c94">

At `GridAlignment.Right`:
<img width="145" alt="image" src="https://github.com/JJConsulting/JJMasterData/assets/52143624/a9d0af38-d8e2-49af-99f1-0dc7c60a7327">
