### PR TITLE
Add alphanumeric CNPJ support to CNPJ component, validation and formatting

### DIFF
--- a/src/MasterData.Commons/Util/Format.cs
+++ b/src/MasterData.Commons/Util/Format.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using System.Linq;
 using System.Text;
 
 namespace JJMasterData.Commons.Util;
@@ -135,14 +136,14 @@ public static class Format
     /// </summary>
     public static string FormatCnpj(string cnpj)
     {
-        string sRet = "";
-        double nCnpj;
-        if (double.TryParse(cnpj, out nCnpj))
-        {
-            sRet = nCnpj.ToString(@"#00\.000\.000\/0000\-00");
-        }
+        var cleanCnpj = StringManager.ClearCpfCnpjChars(cnpj).Trim().ToUpperInvariant();
+        if (cleanCnpj.Length != 14)
+            return string.Empty;
 
-        return sRet;
+        if (!cleanCnpj[..12].All(char.IsLetterOrDigit) || !cleanCnpj[12..].All(char.IsDigit))
+            return string.Empty;
+
+        return $"{cleanCnpj[..2]}.{cleanCnpj.Substring(2, 3)}.{cleanCnpj.Substring(5, 3)}/{cleanCnpj.Substring(8, 4)}-{cleanCnpj[12..]}";
     }
 
     /// <summary>

--- a/src/MasterData.Core/UI/Components/Controls/TextBox/TextGroupFactory.cs
+++ b/src/MasterData.Core/UI/Components/Controls/TextBox/TextGroupFactory.cs
@@ -133,7 +133,7 @@ public sealed class TextGroupFactory(
                 textGroup.InputType = InputType.Text;
                 textGroup.Attributes["onclick"] = "this.select();";
                 textGroup.Attributes["data-inputmask"] =
-                    "'mask': '[99.999.999/9999-99]', 'placeholder':'', 'greedy': 'false'";
+                    "'mask': '[**.***.***/****-99]', 'placeholder':'', 'greedy': 'false'";
                 break;
             case FormComponent.Cpf:
                 textGroup.MaxLength = 14;

--- a/test/MasterData.Commons.Test/Util/FormatTest.cs
+++ b/test/MasterData.Commons.Test/Util/FormatTest.cs
@@ -12,4 +12,14 @@ public class FormatTest
 
         Assert.Equal(expected, text);
     }
+
+    [Theory]
+    [InlineData("19131243000197", "19.131.243/0001-97")]
+    [InlineData("AB.CDE.FGH/IJKL-52", "AB.CDE.FGH/IJKL-52")]
+    public void FormatCnpj_ShouldSupportNumericAndAlphanumeric(string input, string expected)
+    {
+        var result = Format.FormatCnpj(input);
+
+        Assert.Equal(expected, result);
+    }
 }

--- a/test/MasterData.Commons.Test/Validations/ValidateTest.cs
+++ b/test/MasterData.Commons.Test/Validations/ValidateTest.cs
@@ -1,0 +1,23 @@
+﻿using JJMasterData.Commons.Validations;
+
+namespace JJMasterData.Commons.Test.Validations;
+
+public class ValidateTest
+{
+    [Theory]
+    [InlineData("19.131.243/0001-97")]
+    [InlineData("7G.9IZ.AVN/DLVH-20")]
+    public void ValidCnpj_ShouldAcceptNumericAndAlphanumericValues(string input)
+    {
+        Assert.True(Validate.ValidCnpj(input));
+    }
+
+    [Theory]
+    [InlineData("19.131.243/0001-00")]
+    [InlineData("7G.9IZ.AVN/DLVH-00")]
+    [InlineData("7G.9IZ.AVN/DLVH-AA")]
+    public void ValidCnpj_ShouldRejectInvalidValues(string input)
+    {
+        Assert.False(Validate.ValidCnpj(input));
+    }
+}


### PR DESCRIPTION
### Motivation
- Allow CNPJ values containing letters in the root (first 12 positions) to be entered, validated and formatted by the system, matching new business needs for alphanumeric CNPJ support. 

### Description
- Updated CNPJ input mask in `TextGroupFactory` to accept alphanumeric root characters by changing the mask to `"[**.***.***/****-99]"` (file `src/MasterData.Core/UI/Components/Controls/TextBox/TextGroupFactory.cs`).
- Extended validation logic in `Validate.ValidCnpj` to accept alphanumeric roots and compute check digits from alphanumeric characters by adding `CalcularDigitoCnpj` and `ToCnpjValue` helpers (file `src/MasterData.Commons/Validations/Validate.cs`).
- Updated formatter `Format.FormatCnpj` to format alphanumeric CNPJ values without relying on numeric parsing and kept numeric behavior intact (file `src/MasterData.Commons/Util/Format.cs`).
- Added unit tests covering formatting and validation for numeric and alphanumeric CNPJ cases (`test/MasterData.Commons.Test/Util/FormatTest.cs` and `test/MasterData.Commons.Test/Validations/ValidateTest.cs`).

### Testing
- Attempted to run unit tests with `dotnet test test/MasterData.Commons.Test/MasterData.Commons.Test.csproj --no-restore` but the command could not run in this environment because `dotnet` is not installed, so automated tests were not executed here (failed).
- New unit tests were added to the test project to cover the new behavior (`FormatCnpj` and `ValidCnpj`) and should pass when run in an environment with the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698ccd7a02dc8325ac6107350db06fe0)