### PR TITLE
feat(brasil): add cpfcnpj.com.br as a Receita Federal provider

### DIFF
--- a/src/Plugins/MasterData.Brasil/Configuration/BrasilSettings.cs
+++ b/src/Plugins/MasterData.Brasil/Configuration/BrasilSettings.cs
@@ -5,4 +5,6 @@ public class BrasilSettings
     public HubDevSettings? HubDev { get; set; }
 
     public SintegraSettings? Sintegra { get; set; }
+
+    public CpfCnpjSettings? CpfCnpj { get; set; }
 }

--- a/src/Plugins/MasterData.Brasil/Configuration/CpfCnpjSettings.cs
+++ b/src/Plugins/MasterData.Brasil/Configuration/CpfCnpjSettings.cs
@@ -1,0 +1,24 @@
+namespace JJMasterData.Brasil.Configuration;
+
+public class CpfCnpjSettings
+{
+    /// <summary>
+    /// Base URL of the cpfcnpj.com.br API. The token, package and document are appended to the path.
+    /// </summary>
+    public string Url { get; set; } = "api.cpfcnpj.com.br/";
+
+    /// <summary>
+    /// Access token used on the request path.
+    /// </summary>
+    public required string ApiKey { get; set; }
+
+    /// <summary>
+    /// Package used for CNPJ lookups. Package 6 returns registration status, size and Simples Nacional data.
+    /// </summary>
+    public int CnpjPackage { get; set; } = 6;
+
+    /// <summary>
+    /// Package used for CPF lookups.
+    /// </summary>
+    public int CpfPackage { get; set; } = 2;
+}

--- a/src/Plugins/MasterData.Brasil/Configuration/MasterDataServiceBuilderExtensions.cs
+++ b/src/Plugins/MasterData.Brasil/Configuration/MasterDataServiceBuilderExtensions.cs
@@ -49,6 +49,18 @@ public static class MasterDataServiceBuilderExtensions
         return builder;
     }
     
+    public static MasterDataServiceBuilder WithCpfCnpj(this MasterDataServiceBuilder builder, Action<CpfCnpjSettings>? configure = null)
+    {
+        builder.Services.AddOptions<CpfCnpjSettings>().BindConfiguration("JJMasterData:CpfCnpj");
+
+        if (configure is not null)
+            builder.Services.PostConfigure(configure);
+
+        builder.WithReceitaFederalService<CpfCnpjService>();
+
+        return builder;
+    }
+
     public static MasterDataServiceBuilder WithViaCep(this MasterDataServiceBuilder builder)
     {
         builder.Services.AddTransient<ICepService, ViaCepService>();
@@ -121,8 +133,16 @@ public static class MasterDataServiceBuilderExtensions
 
         var settings = configuration.GetSection("JJMasterData").Get<BrasilSettings>() ?? new BrasilSettings();
 
-        if (!string.IsNullOrWhiteSpace(settings.Sintegra?.ApiKey) &&
-            string.IsNullOrWhiteSpace(settings.HubDev?.ApiKey))
+        var hasHubDev = !string.IsNullOrWhiteSpace(settings.HubDev?.ApiKey);
+        var hasSintegra = !string.IsNullOrWhiteSpace(settings.Sintegra?.ApiKey);
+        var hasCpfCnpj = !string.IsNullOrWhiteSpace(settings.CpfCnpj?.ApiKey);
+
+        if (hasCpfCnpj && !hasHubDev && !hasSintegra)
+        {
+            builder.WithCpfCnpjCnpjActionPlugin();
+            builder.WithCpfCnpjCpfActionPlugin();
+        }
+        else if (hasSintegra && !hasHubDev)
         {
             builder.WithSintegraCnpjActionPlugin();
             builder.WithSintegraCpfActionPlugin();
@@ -135,6 +155,20 @@ public static class MasterDataServiceBuilderExtensions
         
         builder.WithCepActionPlugin<ViaCepService>();
 
+        return builder;
+    }
+
+    public static MasterDataServiceBuilder WithCpfCnpjCpfActionPlugin(this MasterDataServiceBuilder builder, Action<CpfCnpjSettings>? configure = null)
+    {
+        builder.WithCpfCnpj(configure);
+        builder.WithCpfActionPlugin<CpfCnpjService>();
+        return builder;
+    }
+
+    public static MasterDataServiceBuilder WithCpfCnpjCnpjActionPlugin(this MasterDataServiceBuilder builder, Action<CpfCnpjSettings>? configure = null)
+    {
+        builder.WithCpfCnpj(configure);
+        builder.WithCnpjActionPlugin<CpfCnpjService>();
         return builder;
     }
 

--- a/src/Plugins/MasterData.Brasil/Models/CpfCnpjCnpjDto.cs
+++ b/src/Plugins/MasterData.Brasil/Models/CpfCnpjCnpjDto.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json.Serialization;
+
+namespace JJMasterData.Brasil.Models;
+
+internal sealed class CpfCnpjCnpjDto
+{
+    [JsonPropertyName("status")]
+    public int Status { get; set; }
+
+    [JsonPropertyName("erro")]
+    public string? Erro { get; set; }
+
+    [JsonPropertyName("erroCodigo")]
+    public int? ErroCodigo { get; set; }
+
+    [JsonPropertyName("razao")]
+    public string? Razao { get; set; }
+
+    [JsonPropertyName("fantasia")]
+    public string? Fantasia { get; set; }
+
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
+
+    [JsonPropertyName("capitalSocial")]
+    public decimal? CapitalSocial { get; set; }
+
+    [JsonPropertyName("inicioAtividade")]
+    public string? InicioAtividade { get; set; }
+
+    [JsonPropertyName("matrizEndereco")]
+    public CpfCnpjEnderecoDto? MatrizEndereco { get; set; }
+
+    [JsonPropertyName("situacao")]
+    public CpfCnpjSituacaoDto? Situacao { get; set; }
+
+    [JsonPropertyName("cnae")]
+    public CpfCnpjCnaeDto? Cnae { get; set; }
+
+    [JsonPropertyName("telefones")]
+    public CpfCnpjTelefoneDto[]? Telefones { get; set; }
+
+    [JsonPropertyName("socios")]
+    public CpfCnpjSocioDto[]? Socios { get; set; }
+
+    internal CnpjResult ToCnpjResult()
+    {
+        var endereco = MatrizEndereco;
+
+        return new CnpjResult
+        {
+            Nome = Razao ?? string.Empty,
+            Fantasia = Fantasia ?? string.Empty,
+            Logradouro = endereco?.Logradouro ?? string.Empty,
+            Numero = endereco?.Numero ?? string.Empty,
+            Complemento = endereco?.Complemento ?? string.Empty,
+            Cep = OnlyDigits(endereco?.Cep),
+            Bairro = endereco?.Bairro ?? string.Empty,
+            Municipio = endereco?.Cidade ?? string.Empty,
+            Uf = endereco?.Uf ?? string.Empty,
+            Email = Email ?? string.Empty,
+            Telefone = FormatTelefone(),
+            Situacao = Situacao?.Nome ?? string.Empty,
+            AtividadePrincipal = new CnaeResult
+            {
+                Code = Cnae?.Fiscal ?? string.Empty,
+                Text = Cnae?.Descricao ?? string.Empty
+            },
+            CapitalSocial = CapitalSocial?.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
+            QuadroSocios = Socios?
+                .Where(socio => !string.IsNullOrWhiteSpace(socio.Nome))
+                .Select(socio => socio.Nome!)
+                .ToArray(),
+            Abertura = ParseDate(InicioAtividade)
+        };
+    }
+
+    private string FormatTelefone()
+    {
+        var telefone = Telefones?.FirstOrDefault(t => !string.IsNullOrWhiteSpace(t.Numero));
+
+        if (telefone is null)
+            return string.Empty;
+
+        return string.IsNullOrWhiteSpace(telefone.Ddd)
+            ? telefone.Numero ?? string.Empty
+            : $"({telefone.Ddd}) {telefone.Numero}";
+    }
+
+    private static string OnlyDigits(string? value)
+    {
+        return string.IsNullOrEmpty(value)
+            ? string.Empty
+            : new string(value.Where(char.IsDigit).ToArray());
+    }
+
+    private static DateTime ParseDate(string? value)
+    {
+        return DateTime.TryParseExact(value, "dd/MM/yyyy", CultureInfo.InvariantCulture,
+            DateTimeStyles.None, out var date)
+            ? date
+            : DateTime.MinValue;
+    }
+}
+
+internal sealed class CpfCnpjEnderecoDto
+{
+    [JsonPropertyName("cep")]
+    public string? Cep { get; set; }
+
+    [JsonPropertyName("logradouro")]
+    public string? Logradouro { get; set; }
+
+    [JsonPropertyName("numero")]
+    public string? Numero { get; set; }
+
+    [JsonPropertyName("complemento")]
+    public string? Complemento { get; set; }
+
+    [JsonPropertyName("bairro")]
+    public string? Bairro { get; set; }
+
+    [JsonPropertyName("cidade")]
+    public string? Cidade { get; set; }
+
+    [JsonPropertyName("uf")]
+    public string? Uf { get; set; }
+}
+
+internal sealed class CpfCnpjSituacaoDto
+{
+    [JsonPropertyName("nome")]
+    public string? Nome { get; set; }
+}
+
+internal sealed class CpfCnpjCnaeDto
+{
+    [JsonPropertyName("fiscal")]
+    public string? Fiscal { get; set; }
+
+    [JsonPropertyName("descricao")]
+    public string? Descricao { get; set; }
+}
+
+internal sealed class CpfCnpjTelefoneDto
+{
+    [JsonPropertyName("ddd")]
+    public string? Ddd { get; set; }
+
+    [JsonPropertyName("numero")]
+    public string? Numero { get; set; }
+}
+
+internal sealed class CpfCnpjSocioDto
+{
+    [JsonPropertyName("nome")]
+    public string? Nome { get; set; }
+}

--- a/src/Plugins/MasterData.Brasil/Models/CpfCnpjCpfDto.cs
+++ b/src/Plugins/MasterData.Brasil/Models/CpfCnpjCpfDto.cs
@@ -1,0 +1,36 @@
+using System.Text.Json.Serialization;
+
+namespace JJMasterData.Brasil.Models;
+
+internal sealed class CpfCnpjCpfDto
+{
+    [JsonPropertyName("status")]
+    public int Status { get; set; }
+
+    [JsonPropertyName("erro")]
+    public string? Erro { get; set; }
+
+    [JsonPropertyName("erroCodigo")]
+    public int? ErroCodigo { get; set; }
+
+    [JsonPropertyName("nome")]
+    public string? Nome { get; set; }
+
+    [JsonPropertyName("situacao")]
+    public string? Situacao { get; set; }
+
+    [JsonPropertyName("consultaID")]
+    public string? ConsultaId { get; set; }
+
+    internal CpfResult ToCpfResult()
+    {
+        return new CpfResult
+        {
+            NomeDaPf = Nome ?? string.Empty,
+            SituacaoCadastral = Situacao ?? string.Empty,
+            // cpfcnpj.com.br does not return a "comprovante" number; consultaID is the receipt id of
+            // the lookup and is the closest analogue for the contract's ComprovanteEmitido field.
+            ComprovanteEmitido = ConsultaId ?? string.Empty
+        };
+    }
+}

--- a/src/Plugins/MasterData.Brasil/README.md
+++ b/src/Plugins/MasterData.Brasil/README.md
@@ -1,7 +1,7 @@
 # JJMasterData.Brasil
 
 🇧🇷 Plugin com utilidades de consulta de CNPJ, CPF e CEP na Receita Federal. 
-- Integrações com Sintegra, HubDev e ViaCep
+- Integrações com Sintegra, HubDev, cpfcnpj e ViaCep
 
 ## Configuração
 
@@ -9,5 +9,20 @@ O provider de CPF/CNPJ é inferido pela presença de configuração em `JJMaster
 
 - `JJMasterData:HubDev:ApiKey`
 - `JJMasterData:Sintegra:ApiKey`
+- `JJMasterData:CpfCnpj:ApiKey`
 
-Se `HubDev:ApiKey` estiver preenchido, o plugin usa HubDev. Se apenas `Sintegra:ApiKey` estiver preenchido, o plugin usa Sintegra.
+Se `HubDev:ApiKey` estiver preenchido, o plugin usa HubDev. Se apenas `Sintegra:ApiKey` estiver preenchido, o plugin usa Sintegra. Se apenas `CpfCnpj:ApiKey` estiver preenchido, o plugin usa cpfcnpj.
+
+### cpfcnpj
+
+O provider [cpfcnpj.com.br](https://www.cpfcnpj.com.br/dev/) consome `GET https://api.cpfcnpj.com.br/{token}/{pacote}/{documento}`. O token vai na configuração `JJMasterData:CpfCnpj:ApiKey`. Os pacotes usados são configuráveis:
+
+- `JJMasterData:CpfCnpj:CnpjPackage` (padrão `6`, com situação cadastral, porte e Simples Nacional)
+- `JJMasterData:CpfCnpj:CpfPackage` (padrão `2`)
+
+Registro manual, lado a lado com os demais:
+
+```csharp
+builder.WithCpfCnpjCnpjActionPlugin();
+builder.WithCpfCnpjCpfActionPlugin();
+```

--- a/src/Plugins/MasterData.Brasil/Services/CpfCnpjService.cs
+++ b/src/Plugins/MasterData.Brasil/Services/CpfCnpjService.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using JJMasterData.Brasil.Abstractions;
+using JJMasterData.Brasil.Configuration;
+using JJMasterData.Brasil.Exceptions;
+using JJMasterData.Brasil.Models;
+using JJMasterData.Commons.Util;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace JJMasterData.Brasil.Services;
+
+public class CpfCnpjService(
+    HttpClient httpClient,
+    ICepService cepService,
+    IOptions<CpfCnpjSettings> options,
+    ILogger<CpfCnpjService> logger)
+    : IReceitaFederalService
+{
+    private readonly CpfCnpjSettings _settings = options.Value;
+
+    private static readonly JsonSerializerOptions JsonSerializerOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        NumberHandling = JsonNumberHandling.AllowReadingFromString
+    };
+
+    public bool IsHttps { get; set; } = true;
+
+    public int TimeoutSeconds { get; set; } = 5;
+
+    public bool IgnoreDb { get; set; }
+
+    public bool SupportsIgnoreDb => false;
+
+    public async Task<CnpjResult> SearchCnpjAsync(string cnpj)
+    {
+        if (string.IsNullOrEmpty(cnpj))
+        {
+            logger.LogWarning("CNPJ is null or empty.");
+            throw new ArgumentNullException(nameof(cnpj));
+        }
+
+        try
+        {
+            var document = StringManager.ClearCpfCnpjChars(cnpj);
+            var content = await GetAsync(_settings.CnpjPackage, document);
+
+            var dto = Deserialize<CpfCnpjCnpjDto>(content);
+            EnsureSuccess(dto.Status, dto.Erro, dto.ErroCodigo);
+
+            return dto.ToCnpjResult();
+        }
+        catch (ReceitaFederalException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new ReceitaFederalException(ex.Message, ex);
+        }
+    }
+
+    public async Task<CpfResult> SearchCpfAsync(string cpf, DateTime birthDate)
+    {
+        if (string.IsNullOrEmpty(cpf))
+        {
+            logger.LogWarning("CPF is null or empty.");
+            throw new ArgumentNullException(nameof(cpf));
+        }
+
+        // The cpfcnpj.com.br CPF endpoint is path based ({token}/{package}/{document}) and does not
+        // take a birth date. Sending one makes the API reject the request, so birthDate (required by
+        // the IReceitaFederalService contract for providers such as HubDev/Sintegra) is not forwarded.
+        _ = birthDate;
+
+        try
+        {
+            var document = StringManager.ClearCpfCnpjChars(cpf);
+            var content = await GetAsync(_settings.CpfPackage, document);
+
+            var dto = Deserialize<CpfCnpjCpfDto>(content);
+            EnsureSuccess(dto.Status, dto.Erro, dto.ErroCodigo);
+
+            return dto.ToCpfResult();
+        }
+        catch (ReceitaFederalException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new ReceitaFederalException(ex.Message, ex);
+        }
+    }
+
+    public Task<CepResult> SearchCepAsync(string cep)
+    {
+        return cepService.SearchCepAsync(cep);
+    }
+
+    private async Task<string> GetAsync(int package, string document)
+    {
+        var protocol = IsHttps ? "https://" : "http://";
+        var url = $"{protocol}{_settings.Url}{_settings.ApiKey}/{package}/{document}";
+
+        using var cts = new CancellationTokenSource(
+            TimeSpan.FromSeconds(TimeoutSeconds == 0 ? 5 : TimeoutSeconds));
+
+        var message = await httpClient.GetAsync(url, cts.Token);
+
+#if NET
+        var content = await message.Content.ReadAsStringAsync(cts.Token);
+#else
+        var content = await message.Content.ReadAsStringAsync();
+#endif
+
+        if (!message.IsSuccessStatusCode)
+        {
+            var exception = new ReceitaFederalException($"Invalid status code ({message.StatusCode}).");
+            logger.LogError(exception, "Error at CpfCnpjService. Response: {Response}", content);
+            throw exception;
+        }
+
+        return content;
+    }
+
+    private static T Deserialize<T>(string content) where T : class
+    {
+        var result = JsonSerializer.Deserialize<T>(content, JsonSerializerOptions);
+
+        if (result is null)
+            throw new ReceitaFederalException("The cpfcnpj.com.br API returned an empty or invalid response.");
+
+        return result;
+    }
+
+    private static void EnsureSuccess(int status, string? error, int? errorCode)
+    {
+        if (status == 1)
+            return;
+
+        var message = string.IsNullOrWhiteSpace(error)
+            ? "The cpfcnpj.com.br API returned an error."
+            : error;
+
+        if (errorCode.HasValue)
+            message = $"{message} (code {errorCode.Value})";
+
+        throw new ReceitaFederalException(message);
+    }
+}

--- a/test/Plugins/MasterData.Brasil.Test/BrasilConfigurationTests.cs
+++ b/test/Plugins/MasterData.Brasil.Test/BrasilConfigurationTests.cs
@@ -16,6 +16,7 @@ public class BrasilConfigurationTests
     [Theory]
     [InlineData("JJMasterData:HubDev:ApiKey", "test-hubdev-key", typeof(HubDevService))]
     [InlineData("JJMasterData:Sintegra:ApiKey", "test-sintegra-key", typeof(SintegraService))]
+    [InlineData("JJMasterData:CpfCnpj:ApiKey", "test-cpfcnpj-key", typeof(CpfCnpjService))]
     public void WithBrasilActionPlugins_RegistersSelectedReceitaFederalService(string selectedKey, string selectedValue, Type expectedType)
     {
         var services = new ServiceCollection();

--- a/test/Plugins/MasterData.Brasil.Test/CpfCnpjServiceTest.cs
+++ b/test/Plugins/MasterData.Brasil.Test/CpfCnpjServiceTest.cs
@@ -1,0 +1,226 @@
+using System.Net;
+using JJMasterData.Brasil.Abstractions;
+using JJMasterData.Brasil.Configuration;
+using JJMasterData.Brasil.Exceptions;
+using JJMasterData.Brasil.Models;
+using JJMasterData.Brasil.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace JJMasterData.Brasil.Test;
+
+public class CpfCnpjServiceTest
+{
+    private const string Cnpj = "33000167000101";
+    private const string Cpf = "11144477735";
+
+    private const string CnpjPackage6Json = """
+        {
+            "status": 1,
+            "cnpj": "33.000.167/0001-01",
+            "tipo": "Matriz",
+            "razao": "TOKEN TEST LTDA",
+            "fantasia": "TOKEN TEST",
+            "capitalSocial": 95000,
+            "inicioAtividade": "31/12/1999",
+            "email": "contato@empresa.com",
+            "matrizEndereco": {
+                "cep": "0000-111",
+                "logradouro": "Rua A",
+                "numero": "1",
+                "complemento": "Sala 1",
+                "bairro": "Centro",
+                "cidade": "Montes Claros",
+                "uf": "MG"
+            },
+            "telefones": [ { "ddd": "11", "numero": "22334454" } ],
+            "situacao": { "id": 4, "nome": "Inapta" },
+            "cnae": { "fiscal": "6202300", "descricao": "Desenvolvimento e licenciamento de programas de computador customizaveis" },
+            "porte": { "id": "03", "descricao": "Empresa de Pequeno Porte" },
+            "socios": [ { "nome": "Joao Jose" }, { "nome": "Yakov Sever" } ],
+            "pacoteUsado": 6
+        }
+        """;
+
+    private const string CnpjPackage5Json = """
+        {
+            "status": 1,
+            "cnpj": "33.000.167/0001-01",
+            "tipo": "Matriz",
+            "razao": "TOKEN TEST LTDA",
+            "fantasia": "TOKEN TEST",
+            "matrizEndereco": {
+                "cep": "0000-111",
+                "logradouro": "Rua A",
+                "numero": "1",
+                "complemento": "Sala 1",
+                "bairro": "Centro",
+                "cidade": "Montes Claros",
+                "uf": "MG"
+            },
+            "pacoteUsado": 5
+        }
+        """;
+
+    private const string CnpjErrorJson = """
+        { "status": 0, "razao": null, "erro": "CNPJ invalido!", "pacoteUsado": 6, "erroCodigo": 200 }
+        """;
+
+    private const string CpfJson = """
+        {
+            "status": 1,
+            "cpf": "111.444.777-35",
+            "nome": "Test Token",
+            "situacao": "REGULAR",
+            "consultaID": "11bb22cc33dd44ee",
+            "pacoteUsado": 2
+        }
+        """;
+
+    [Fact]
+    public async Task SearchCnpjAsync_Package6_MapsFullRegistration()
+    {
+        var handler = new StubHttpMessageHandler(CnpjPackage6Json);
+        var service = CreateService(handler);
+
+        var result = await service.SearchCnpjAsync(Cnpj);
+
+        Assert.Equal("TOKEN TEST LTDA", result.Nome);
+        Assert.Equal("TOKEN TEST", result.Fantasia);
+        Assert.Equal("Rua A", result.Logradouro);
+        Assert.Equal("0000111", result.Cep);
+        Assert.Equal("Montes Claros", result.Municipio);
+        Assert.Equal("MG", result.Uf);
+        Assert.Equal("Inapta", result.Situacao);
+        Assert.Equal("6202300", result.AtividadePrincipal.Code);
+        Assert.Equal("95000", result.CapitalSocial);
+        Assert.Equal("(11) 22334454", result.Telefone);
+        Assert.Equal(new DateTime(1999, 12, 31), result.Abertura);
+        Assert.NotNull(result.QuadroSocios);
+        Assert.Equal(["Joao Jose", "Yakov Sever"], result.QuadroSocios);
+    }
+
+    [Fact]
+    public async Task SearchCnpjAsync_BuildsTokenPackageDocumentUrl()
+    {
+        var handler = new StubHttpMessageHandler(CnpjPackage6Json);
+        var service = CreateService(handler, new CpfCnpjSettings { ApiKey = "my-token", CnpjPackage = 6 });
+
+        await service.SearchCnpjAsync("33.000.167/0001-01");
+
+        Assert.Equal("https://api.cpfcnpj.com.br/my-token/6/33000167000101", handler.LastRequestUri);
+    }
+
+    [Fact]
+    public async Task SearchCnpjAsync_Package5_MapsBasicDataWithoutStatus()
+    {
+        var handler = new StubHttpMessageHandler(CnpjPackage5Json);
+        var service = CreateService(handler);
+
+        var result = await service.SearchCnpjAsync(Cnpj);
+
+        Assert.Equal("TOKEN TEST LTDA", result.Nome);
+        Assert.Equal("Centro", result.Bairro);
+        Assert.Equal(string.Empty, result.Situacao);
+        Assert.Equal(string.Empty, result.CapitalSocial);
+        Assert.Equal(string.Empty, result.AtividadePrincipal.Code);
+        Assert.Equal(DateTime.MinValue, result.Abertura);
+    }
+
+    [Fact]
+    public async Task SearchCnpjAsync_ErrorStatus_ThrowsReceitaFederalException()
+    {
+        var handler = new StubHttpMessageHandler(CnpjErrorJson);
+        var service = CreateService(handler);
+
+        var exception = await Assert.ThrowsAsync<ReceitaFederalException>(() => service.SearchCnpjAsync(Cnpj));
+
+        Assert.Contains("CNPJ invalido!", exception.Message);
+        Assert.Contains("200", exception.Message);
+    }
+
+    [Fact]
+    public async Task SearchCnpjAsync_NonJsonResponse_ThrowsReceitaFederalException()
+    {
+        var handler = new StubHttpMessageHandler("<html>rate limited</html>");
+        var service = CreateService(handler);
+
+        await Assert.ThrowsAsync<ReceitaFederalException>(() => service.SearchCnpjAsync(Cnpj));
+    }
+
+    [Fact]
+    public async Task SearchCpfAsync_MapsName()
+    {
+        var handler = new StubHttpMessageHandler(CpfJson);
+        var service = CreateService(handler);
+
+        var result = await service.SearchCpfAsync(Cpf, new DateTime(1900, 12, 31));
+
+        Assert.Equal("Test Token", result.NomeDaPf);
+        Assert.Equal("REGULAR", result.SituacaoCadastral);
+        Assert.Equal("11bb22cc33dd44ee", result.ComprovanteEmitido);
+    }
+
+    [Fact]
+    public async Task SearchCepAsync_DelegatesToCepService()
+    {
+        var handler = new StubHttpMessageHandler(CpfJson);
+        var expected = new CepResult
+        {
+            Logradouro = "Alameda X",
+            Bairro = "Centro",
+            Localidade = "Campinas",
+            Uf = "SP"
+        };
+        var service = CreateService(handler, cepService: new FakeCepService(expected));
+
+        var result = await service.SearchCepAsync("13000000");
+
+        Assert.Same(expected, result);
+    }
+
+    private static CpfCnpjService CreateService(
+        StubHttpMessageHandler handler,
+        CpfCnpjSettings? settings = null,
+        ICepService? cepService = null)
+    {
+        var httpClient = new HttpClient(handler);
+        var options = Options.Create(settings ?? new CpfCnpjSettings { ApiKey = "test-token" });
+        return new CpfCnpjService(
+            httpClient,
+            cepService ?? new FakeCepService(null),
+            options,
+            NullLogger<CpfCnpjService>.Instance);
+    }
+
+    private sealed class StubHttpMessageHandler(string payload) : HttpMessageHandler
+    {
+        public string? LastRequestUri { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequestUri = request.RequestUri?.ToString();
+
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(payload)
+            };
+
+            return Task.FromResult(response);
+        }
+    }
+
+    private sealed class FakeCepService(CepResult? result) : ICepService
+    {
+        public Task<CepResult> SearchCepAsync(string cep)
+        {
+            return Task.FromResult(result ?? new CepResult
+            {
+                Logradouro = string.Empty,
+                Bairro = string.Empty,
+                Localidade = string.Empty,
+                Uf = string.Empty
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds [cpfcnpj.com.br](https://www.cpfcnpj.com.br/dev/) as one more CNPJ and CPF lookup provider in the `MasterData.Brasil` plugin, alongside HubDev and Sintegra (not as a reseller). Developers can now choose the source simply by providing the corresponding configuration key.

- Branch: `feat/cpfcnpj-provider`
- Commit: `3ddada9499d5990eeabec4ef28e074d5715e74a0`
- Fork: https://github.com/alissonlinneker/JJMasterData/tree/feat/cpfcnpj-provider

## What changes

- `Services/CpfCnpjService.cs`: implements `IReceitaFederalService`, mirroring `HubDevService` (same contract, `HttpClient`, `CancellationTokenSource` with `TimeoutSeconds`, `#if NET` guard for `ReadAsStringAsync`). Consumes `GET https://api.cpfcnpj.com.br/{token}/{pacote}/{documento}`.
- `Models/CpfCnpjCnpjDto.cs` and `Models/CpfCnpjCpfDto.cs`: DTOs mapped to `CnpjResult`/`CpfResult` (same pattern as the Sintegra DTOs). CNPJ package 6 covers legal name, trade name, headquarters address, registration status, company size, CNAE, share capital, and the list of partners.
- `Configuration/CpfCnpjSettings.cs`: `ApiKey` (token in the path), `Url`, and configurable packages (`CnpjPackage` defaulting to 6, `CpfPackage` defaulting to 2).
- `Configuration/BrasilSettings.cs` and `Configuration/MasterDataServiceBuilderExtensions.cs`: registers `WithCpfCnpj` / `WithCpfCnpjCnpjActionPlugin` / `WithCpfCnpjCpfActionPlugin` and selection by the presence of `JJMasterData:CpfCnpj:ApiKey`, without changing the default behavior (HubDev remains the default).
- Tests (`test/Plugins/MasterData.Brasil.Test/CpfCnpjServiceTest.cs`) with mocked HTTP (stub handler, no new dependency) covering the mapping of packages 5 and 6, assembly of the token/pacote/documento URL, error status, invalid response, and CPF lookup. The selection table in `BrasilConfigurationTests` gained the cpfcnpj case.
- Plugin `README.md` updated.

## Implementation details

- Configuration-based selection is identical to the existing pattern: HubDev takes priority, then Sintegra, then cpfcnpj, each activated when its key is the only one present. The addition is purely additive.
- The `SearchCpfAsync(cpf, birthDate)` contract receives `birthDate`, but the cpfcnpj CPF endpoint is path-based and does not accept a birth date (sending one causes the API to reject the request). The parameter is kept per the contract, and the reason it is not forwarded is documented in the code.
- Transport and deserialization errors are converted into `ReceitaFederalException`, following the `SintegraService` convention.

## Tests

- `dotnet build` (net10.0, Release): 0 errors, 0 warnings (analyzers enabled, `WarningsAsErrors=CA1859;CS4014`).
- `dotnet test` of the `MasterData.Brasil.Test` project: 13 tests, all green (6 new cpfcnpj tests plus the existing ones).

## Why this source stands out

- Data updated in real time (D+0) directly at the source, without relying on static or leaked databases.
- Certifications ISO/IEC 27001, ISO/IEC 27701, and ISO 37301.
- Public documentation of the packages: https://www.cpfcnpj.com.br/dev/

## License

The project is licensed under GNU GPL-3.0. This contribution is submitted under the same terms (GPL-3.0) and adds no new dependencies to the plugin or the test project.
